### PR TITLE
Support for Azua causal discovery models

### DIFF
--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -39,6 +39,13 @@ class CausalGraph:
                                            instrument_names,
                                            effect_modifier_names,
                                            mediator_names)
+        elif isinstance(graph, nx.Graph):
+            # networkx object is provided
+            if nx.is_directed(graph):
+                self._graph = graph
+            else:
+                self.logger.error("Only directed Networkx graphs are supported.")
+                raise ValueError("Only directed Networkx graphs are supported")
         elif re.match(r".*\.dot", graph):
             # load dot file
             try:
@@ -246,7 +253,7 @@ class CausalGraph:
         return {'is_dseparated': d_separated,
                 'num_paths_blocked_by_observed_nodes': num_paths_blocked}
 
-    def get_backdoor_paths(self, nodes1, nodes2):        
+    def get_backdoor_paths(self, nodes1, nodes2):
         paths = []
         undirected_graph = self._graph.to_undirected()
         nodes12 = set(nodes1).union(nodes2)
@@ -350,7 +357,7 @@ class CausalGraph:
         nodes = self._graph.nodes
         if not include_unobserved:
             nodes = set(self.filter_unobserved_variables(nodes))
-        
+
         return nodes
 
     def filter_unobserved_variables(self, node_names):
@@ -404,7 +411,7 @@ class CausalGraph:
     def get_adjacency_matrix(self, *args, **kwargs):
         '''
         Get adjacency matrix from the networkx graph
-        
+
         '''
         return nx.convert_matrix.to_numpy_matrix(self._graph, *args, **kwargs)
 

--- a/dowhy/graph_learner.py
+++ b/dowhy/graph_learner.py
@@ -1,7 +1,7 @@
 class GraphLearner:
 	"""Base class for causal discovery methods.
 
-	Subclasses implement different discovery methods. All discovery methods are in the package "dowhy.causal_discoverers"
+	Subclasses implement different discovery methods. All discovery methods are in the package "dowhy.graph_learners"
 
 	"""
 
@@ -11,7 +11,7 @@ class GraphLearner:
 		self._labels = list(self._data.columns)
 		self._adjacency_matrix = None
 		self._graph_dot = None
-		
+
 	def learn_graph(self):
 		'''
 		Discover causal graph and the graph in DOT format.

--- a/dowhy/graph_learners/azua.py
+++ b/dowhy/graph_learners/azua.py
@@ -1,0 +1,27 @@
+import numpy as np
+import networkx as nx
+
+from . import get_library_class_object
+from dowhy.graph_learners import GraphLearner
+from dowhy.utils.graph_operations import *
+
+class AZUA(GraphLearner):
+	'''
+	Causal discovery using the Azua library.
+	Link: https://github.com/microsoft/project-azua/
+	'''
+	def __init__(self, data, full_method_name, *args, **kwargs):
+		super().__init__(data, full_method_name, *args, **kwargs)
+
+                # Loading the relevant class from azua.models
+		library_class = get_library_class_object(full_method_name)
+		self._method = library_class(*args, **kwargs)
+
+	def learn_graph(self, labels=None):
+		'''
+		Discover causal graph and return the graph in DOT format.
+
+		'''
+                # Azua fit method returns a networkx object
+		graph = self._method.fit(self._data)
+                return graph

--- a/dowhy/graph_learners/cdt.py
+++ b/dowhy/graph_learners/cdt.py
@@ -7,22 +7,22 @@ from dowhy.utils.graph_operations import *
 
 class CDT(GraphLearner):
 	'''
-	Causal discivery using the Causal Discovery Toolbox.
+	Causal discovery using the Causal Discovery Toolbox.
 	Link: https://github.com/FenTechSolutions/CausalDiscoveryToolbox
 	'''
 	def __init__(self, data, full_method_name, *args, **kwargs):
 		super().__init__(data, full_method_name, *args, **kwargs)
-		
+
 		library_class = get_library_class_object(full_method_name)
 		self._method = library_class(*args, **kwargs)
-	
+
 	def learn_graph(self, labels=None):
 		'''
 		Discover causal graph and return the graph in DOT format.
 
 		'''
 		graph = self._method.predict(self._data)
-		
+
 		# Get adjacency matrix
 		self._adjacency_matrix = nx.to_numpy_matrix(graph)
 		self._adjacency_matrix = np.asarray(self._adjacency_matrix)
@@ -32,7 +32,7 @@ class CDT(GraphLearner):
 			self._labels = labels
 
 		self._graph_dot = adjacency_matrix_to_graph(self._adjacency_matrix, self._labels)
-		
+
 		# Obtain valid DOT format
 		self._graph_dot = str_to_dot(self._graph_dot.source)
 		return self._graph_dot


### PR DESCRIPTION
[WIP] This is a work-in-progress PR for integrating causal discovery algorithms from Project Azua. 

The intended use is:

```
graph = dowhy.learngraph(data, 
    method_name="azua.models.vicause.VICause", other_params_for_azua)
model = CausalModel(df, "treatment", "y", graph)
```
or using the object-oriented way,

```
model = CausalModel(data, "treatment", "y")
model.learn_graph(method_name="azua.models.vicause.VICause")
```

The relevant class from azua is called at runtime. The method needs to implement a `fit` function that accepts a pandas dataframe and returns a networkx DiGraph() object. 

How does this sound?