### PR TITLE
Fix scikit-learn to 1.0.2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install 'numpy<=1.21' --force-reinstall
         if [ -f requirements-plotting.txt ]; then pip install -r requirements-plotting.txt; fi
+        pip install 'scikit-learn==1.0.2' --force-reinstall
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt --use-deprecated=legacy-resolver; fi
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
This follows a recent change in causalml: https://github.com/uber/causalml/commit/939b962c54a4fbea835f686e2f82ab1d4e4bc8f8 and should fix dependency installation for tests.