### PR TITLE
Adjust gcm documentation to current features

### DIFF
--- a/docs/source/gcm/user_guide/answering_causal_questions/attribute_distributional_changes.rst
+++ b/docs/source/gcm/user_guide/answering_causal_questions/attribute_distributional_changes.rst
@@ -17,12 +17,12 @@ deployment:
 >>> import networkx as nx, numpy as np, pandas as pd
 >>> from dowhy import gcm
 >>> from scipy.stats import halfnorm
->>>
+
 >>> X = halfnorm.rvs(size=1000, loc=0.5, scale=0.2)
 >>> Y = halfnorm.rvs(size=1000, loc=1.0, scale=0.2)
 >>> Z = np.maximum(X, Y) + np.random.normal(loc=0, scale=1, size=1000)
 >>> data_old = pd.DataFrame(data=dict(X=X, Y=Y, Z=Z))
->>>
+
 >>> X = halfnorm.rvs(size=1000, loc=0.5, scale=0.2)
 >>> Y = halfnorm.rvs(size=1000, loc=1.0, scale=0.2)
 >>> Z = X + Y + np.random.normal(loc=0, scale=1, size=1000)
@@ -34,7 +34,9 @@ parallel vs. waiting for them sequentially).
 Next, we'll model cause-effect relationships as a probabilistic causal model:
 
 >>> causal_model = gcm.ProbabilisticCausalModel(nx.DiGraph([('X', 'Z'), ('Y', 'Z')]))  # X -> Z <- Y
->>> gcm.auto_assign_causal_models(causal_model, based_on=data_old)
+>>> causal_model.set_causal_mechanism('X', gcm.EmpiricalDistribution())
+>>> causal_model.set_causal_mechanism('Y', gcm.EmpiricalDistribution())
+>>> causal_model.set_causal_mechanism('Z', gcm.AdditiveNoiseModel(gcm.ml.create_linear_regressor()))
 
 Finally, we attribute changes in distributions to changes in causal mechanisms:
 

--- a/docs/source/gcm/user_guide/answering_causal_questions/computing_counterfactuals.rst
+++ b/docs/source/gcm/user_guide/answering_causal_questions/computing_counterfactuals.rst
@@ -20,7 +20,7 @@ To see how the method works, let's generate some data:
 
 >>> import networkx as nx, numpy as np, pandas as pd
 >>> from dowhy import gcm
->>>
+
 >>> X = np.random.normal(loc=0, scale=1, size=1000)
 >>> Y = 2*X + np.random.normal(loc=0, scale=1, size=1000)
 >>> Z = 3*Y + np.random.normal(loc=0, scale=1, size=1000)
@@ -29,13 +29,15 @@ To see how the method works, let's generate some data:
 Next, we'll model cause-effect relationships as an invertible SCM and fit it to the data:
 
 >>> causal_model = gcm.InvertibleStructuralCausalModel(nx.DiGraph([('X', 'Y'), ('Y', 'Z')])) # X -> Y -> Z
->>> gcm.auto_assign_causal_models(causal_model, training_data, gcm.AutoAssignQuality.GOOD)
->>>
+>>> causal_model.set_causal_mechanism('X', gcm.EmpiricalDistribution())
+>>> causal_model.set_causal_mechanism('Y', gcm.AdditiveNoiseModel(gcm.ml.create_linear_regressor()))
+>>> causal_model.set_causal_mechanism('Z', gcm.AdditiveNoiseModel(gcm.ml.create_linear_regressor()))
+
 >>> gcm.fit(causal_model, training_data)
 
 Finally, let's compute the counterfactual when intervening on X:
 
->>> gcm.estimate_counterfactuals(
+>>> gcm.counterfactual_samples(
 >>>     causal_model,
 >>>     {'X': lambda x: 2},
 >>>     observed_data=pd.DataFrame(data=dict(X=[1], Y=[2], Z=[3])))
@@ -53,7 +55,7 @@ estimate the counterfactual value of :math:`Z`, had we set :math:`X := 2`, which
 This shows that the observed data is used to calculate the noise data in the system. We can also
 provide these noise values directly, via:
 
->>> gcm.counterfactual_distribution(
+>>> gcm.counterfactual_samples(
 >>>     causal_model,
 >>>     {'X': lambda x: 2},
 >>>     noise_data=pd.DataFrame(data=dict(X=[0], Y=[-0.007913], Z=[-2.97568])))

--- a/docs/source/gcm/user_guide/answering_causal_questions/index.rst
+++ b/docs/source/gcm/user_guide/answering_causal_questions/index.rst
@@ -6,7 +6,7 @@ DoWhy can answer and explain the concepts behind them and how to interpret the r
 
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 1
 
     simulate_impact_of_interventions
     computing_counterfactuals

--- a/docs/source/gcm/user_guide/customizing_model_assignment.rst
+++ b/docs/source/gcm/user_guide/customizing_model_assignment.rst
@@ -1,4 +1,4 @@
 Customizing Model Assignment
 ============================
 
-TODO
+Coming soon.


### PR DESCRIPTION
* Remove auto-assign. We can re-introduce auto-assigning causal models once the module was merged.
* Fix names of causal queries.