### PR TITLE
Skip experimental import when sklearn version is >= 1.0

### DIFF
--- a/dowhy/gcm/ml/classification.py
+++ b/dowhy/gcm/ml/classification.py
@@ -6,7 +6,11 @@ from typing import List
 
 import numpy as np
 import sklearn
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+from packaging import version
+
+if version.parse(sklearn.__version__) < version.parse("1.0"):
+    from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+
 from sklearn.ensemble import RandomForestClassifier, HistGradientBoostingClassifier
 from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.linear_model import LogisticRegression

--- a/dowhy/gcm/ml/regression.py
+++ b/dowhy/gcm/ml/regression.py
@@ -6,7 +6,11 @@ from typing import Any
 
 import numpy as np
 import sklearn
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+from packaging import version
+
+if version.parse(sklearn.__version__) < version.parse("1.0"):
+    from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+
 from sklearn.ensemble import RandomForestRegressor, HistGradientBoostingRegressor
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.linear_model import LinearRegression, RidgeCV, LassoCV, LassoLarsIC, ElasticNetCV


### PR DESCRIPTION
This avoids the user warning 

"Since version 1.0, it is not needed to import enable_hist_gradient_boosting anymore. HistGradientBoostingClassifier and HistGradientBoostingRegressor are now stable and can be normally imported from sklearn.ensemble."

for users with a newer (>= 1.0) scitkit-learn version.