### PR TITLE
Revise and refactor kernel tests

### DIFF
--- a/dowhy/gcm/independence_test/kernel_operation.py
+++ b/dowhy/gcm/independence_test/kernel_operation.py
@@ -4,7 +4,7 @@ future.
 
 from typing import Optional, List, Callable
 
-import numpy
+import numpy as np
 from sklearn.kernel_approximation import Nystroem
 from sklearn.metrics import euclidean_distances
 from sklearn.preprocessing import scale
@@ -12,45 +12,39 @@ from sklearn.preprocessing import scale
 from dowhy.gcm.util.general import shape_into_2d, is_categorical
 
 
-def apply_rbf_kernel(X: numpy.ndarray,
-                     scale_data: bool = True,
-                     precision: Optional[float] = None) -> numpy.ndarray:
-    """Estimates the RBF (Gaussian) kernel for the given input data.
+def apply_rbf_kernel(X: np.ndarray,
+                     precision: Optional[float] = None) -> np.ndarray:
+    """
+    Estimates the RBF (Gaussian) kernel for the given input data.
 
     :param X: Input data.
-    :param scale_data: True if the data should be standardize.
     :param precision: Specific precision matrix for the RBF kernel. If None is given, this is inferred from the data.
     :return: The outcome of applying a RBF (Gaussian) kernel on the data.
     """
     X = shape_into_2d(X)
-    if scale_data:
-        X = scale(X)
 
     distance_matrix = euclidean_distances(X, squared=True)
 
     if precision is None:
-        tmp = numpy.sqrt(distance_matrix)
-        tmp = tmp - numpy.tril(tmp, -1)
-        tmp = tmp.reshape(-1, 1)
-        precision = 1 / numpy.median(tmp[tmp > 0])
+        precision = _median_based_precision(X)
 
-    return numpy.exp(-precision * distance_matrix)
+    return np.exp(-precision * distance_matrix)
 
 
-def apply_delta_kernel(X: numpy.ndarray) -> numpy.ndarray:
+def apply_delta_kernel(X: np.ndarray) -> np.ndarray:
     """Applies the delta kernel, i.e. the distance is 1 if two entries are equal and 0 otherwise.
 
     :param X: Input data.
     :return: The outcome of the delta-kernel, a binary distance matrix.
     """
     X = shape_into_2d(X)
-    return numpy.array(list(map(lambda value: value == X, X))).reshape(X.shape[0], X.shape[0]).astype(numpy.float)
+    return np.array(list(map(lambda value: value == X, X))).reshape(X.shape[0], X.shape[0]).astype(np.float)
 
 
-def approximate_rbf_kernel_features(X: numpy.ndarray,
+def approximate_rbf_kernel_features(X: np.ndarray,
                                     num_random_components: int,
                                     scale_data: bool = False,
-                                    precision: Optional[float] = None) -> numpy.ndarray:
+                                    precision: Optional[float] = None) -> np.ndarray:
     """Applies the Nystroem method to create a NxD (D << N) approximated RBF kernel map using a subset of the data,
     where N is the number of samples in X and D the number of components.
 
@@ -65,15 +59,12 @@ def approximate_rbf_kernel_features(X: numpy.ndarray,
         X = scale(X)
 
     if precision is None:
-        tmp = numpy.sqrt(euclidean_distances(X, squared=True))
-        tmp = tmp - numpy.tril(tmp, -1)
-        tmp = tmp.reshape(-1, 1)
-        precision = 1 / numpy.median(tmp[tmp > 0])
+        precision = _median_based_precision(X)
 
     return Nystroem(kernel='rbf', gamma=precision, n_components=num_random_components).fit_transform(X)
 
 
-def approximate_delta_kernel_features(X: numpy.ndarray, num_random_components: int) -> numpy.ndarray:
+def approximate_delta_kernel_features(X: np.ndarray, num_random_components: int) -> np.ndarray:
     """Applies the Nystroem method to create a NxD (D << N) approximated delta kernel map using a subset of the data,
     where N is the number of samples in X and D the number of components. The delta kernel gives 1 if two entries are
     equal and 0 otherwise.
@@ -89,7 +80,7 @@ def approximate_delta_kernel_features(X: numpy.ndarray, num_random_components: i
     def delta_function(x, y) -> float:
         return float(x == y)
 
-    for i, unique_element in enumerate(numpy.unique(X)):
+    for i, unique_element in enumerate(np.unique(X)):
         X[X == unique_element] = i
 
     result = Nystroem(kernel=delta_function, n_components=num_random_components).fit_transform(X.astype(int))
@@ -98,7 +89,7 @@ def approximate_delta_kernel_features(X: numpy.ndarray, num_random_components: i
     return result
 
 
-def auto_create_list_of_kernels(X: numpy.ndarray) -> List[Callable[[numpy.ndarray], numpy.ndarray]]:
+def auto_create_list_of_kernels(X: np.ndarray) -> List[Callable[[np.ndarray], np.ndarray]]:
     X = shape_into_2d(X)
 
     tmp_list = []
@@ -111,7 +102,7 @@ def auto_create_list_of_kernels(X: numpy.ndarray) -> List[Callable[[numpy.ndarra
     return tmp_list
 
 
-def auto_create_list_of_kernel_approximations(X: numpy.ndarray) -> List[Callable[[numpy.ndarray, int], numpy.ndarray]]:
+def auto_create_list_of_kernel_approximations(X: np.ndarray) -> List[Callable[[np.ndarray, int], np.ndarray]]:
     X = shape_into_2d(X)
 
     tmp_list = []
@@ -122,3 +113,11 @@ def auto_create_list_of_kernel_approximations(X: numpy.ndarray) -> List[Callable
             tmp_list.append(approximate_delta_kernel_features)
 
     return tmp_list
+
+
+def _median_based_precision(X: np.ndarray) -> float:
+    tmp = np.sqrt(euclidean_distances(X, squared=True))
+    tmp = tmp - np.tril(tmp, -1)
+    tmp = tmp.reshape(-1, 1)
+
+    return 1 / np.median(tmp[tmp > 0])


### PR DESCRIPTION
Simplified kernel tests. Now, the inputs are converted to numeric vectors and one specific kernel is used for all variables (instead of a different kernel per feature). This simplifies the customization of the utilized kernel and using the lambda function still offers the flexibility to concatenate different kernels into one function.