### PR TITLE
Add GCM feature relevance module

### DIFF
--- a/dowhy/gcm/__init__.py
+++ b/dowhy/gcm/__init__.py
@@ -18,3 +18,4 @@ from . import util, ml, auto
 from .anomaly import attribute_anomalies, anomaly_scores
 from .anomaly_scorers import InverseDensityScorer, ITAnomalyScorer, MeanDeviationScorer, MedianDeviationScorer, \
     MedianCDFQuantileScorer, RescaledMedianCDFQuantileScorer
+from .feature import parent_relevance, feature_relevance_distribution, feature_relevance_sample

--- a/dowhy/gcm/feature.py
+++ b/dowhy/gcm/feature.py
@@ -1,0 +1,257 @@
+"""This module allows to estimate the feature relevance of inputs with respect to a given model. While these models can
+be blackbox prediction models, it is also possible to explain causal mechanisms with respect to the direct parents.
+In these cases, it would be possible to incorporate the noise to represent the part of the generation process that
+cannot be explained by the parents.
+
+Functions in this module should be considered experimental, meaning there might be breaking API changes in the future.
+"""
+from typing import Any, Callable, Tuple, Dict, Union, Optional
+
+import numpy as np
+import pandas as pd
+
+from dowhy.gcm.cms import StructuralCausalModel
+from dowhy.gcm.fcms import ProbabilityEstimatorModel
+from dowhy.gcm.fitting_sampling import draw_samples
+from dowhy.gcm.graph import get_ordered_predecessors, is_root_node, validate_node
+from dowhy.gcm.shapley import estimate_shapley_values, ShapleyConfig
+from dowhy.gcm.stats import marginal_expectation
+from dowhy.gcm.util.general import shape_into_2d, variance_of_matching_values, variance_of_deviations
+
+
+def parent_relevance(causal_model: StructuralCausalModel,
+                     target_node: Any,
+                     parent_samples: Optional[pd.DataFrame] = None,
+                     subset_scoring_func:
+                     Optional[Callable[[np.ndarray, np.ndarray], Union[np.ndarray, float]]] = None,
+                     num_background_samples: int = 5000,
+                     num_evaluation_samples: int = 500,
+                     max_batch_size: int = 100,
+                     shapley_config: Optional[ShapleyConfig] = None) -> Tuple[Dict[Any, Any], np.ndarray]:
+    """Estimates the distribution based relevance of the direct parents of the given target_node. This is, the 
+    relevance of direct parents as input features of the the underlying causal model of target_node. Here, the 
+    unobserved noise is considered as a direct parent (input) as well. Samples utilized for the estimation are drawn 
+    from the given causal graph.
+    
+    By default, the used subset_scoring_func is based on the variance between Y and Y', where Y is the outputs of
+    the causal model and Y' the outputs of the models when certain features are randomized. In case of continuous data,
+    the feature relevance adds up to Var(Y - Y').
+    
+    Note: The feature relevance based on the distribution cannot be directly compared with the feature relevance for 
+    single samples. If this is desired, the set function needs to be defined accordingly.
+    
+    Related paper:
+    Janzing, D., Minorics, L., & Bloebaum, P. (2020). 
+    Feature relevance quantification in explainable AI: A causal problem. 
+    In International Conference on Artificial Intelligence and Statistics (pp. 2907-2916). PMLR.
+    
+    :param causal_model: The fitted structural causal model.
+    :param target_node: Node with the causal model of interest.
+    :param parent_samples: Samples for the parents of the given target_node. If None is given, new samples are
+                           generated based on the graph.
+    :param subset_scoring_func: Set function for estimating the quantity of interest based on the model outcomes. This function
+                                expects two inputs; the outcome of the causal model for some samples if certain features are permuted and the 
+                                outcome of the model for the same samples when no features were permuted. The set functions represents the 
+                                comparison between the samples, for instance, the variance of deviations. This is then used as the 'characteristic function'
+                                in coalition games when estimating the Shapley values.
+    :param num_background_samples: Number of samples used as background parent samples for evaluating the set function. 
+                                   If no parent_samples are given, this represents the number of generated samples from
+                                   the joint distribution of the parents. Consider increasing this number for more 
+                                   accurate results or reducing it for less memory consumption and faster runtime.
+    :param num_evaluation_samples: Number of samples on which the set functions are evaluated on. Consider increasing 
+                                   this number for more accurate results or reducing it for less memory consumption and faster runtime.
+    :param max_batch_size: Maximum batch size for estimating multiple predictions at once. This has a significant influence on the
+                          overall memory usage. If set to -1, all samples are used in one batch.
+    :param shapley_config: :class:`~dowhy.gcm.shapley.ShapleyConfig` for the Shapley estimator.
+    :return: There are two return vales. A dictionary with the feature relevance for each direct parent of the given 
+             target_node and the feature relevance of noise.
+    """
+    validate_node(causal_model.graph, target_node)
+
+    if is_root_node(causal_model.graph, target_node):
+        raise ValueError("Cannot compute feature relevance of parents for the target node %s as it is a root node."
+                         "It does not have parents." % target_node)
+
+    ordered_predecessors = get_ordered_predecessors(causal_model.graph, target_node)
+
+    if parent_samples is None:
+        parent_samples \
+            = draw_samples(causal_model, max(num_background_samples, num_evaluation_samples))[ordered_predecessors]
+
+    if subset_scoring_func is None:
+        if isinstance(causal_model.causal_mechanism(target_node), ProbabilityEstimatorModel):
+            subset_scoring_func = variance_of_matching_values
+        else:
+            subset_scoring_func = variance_of_deviations
+
+    parent_samples = shape_into_2d(parent_samples[ordered_predecessors].to_numpy())
+    noise_samples = shape_into_2d(
+        causal_model.causal_mechanism(target_node).draw_noise_samples(parent_samples.shape[0]))
+    samples_features = np.column_stack([parent_samples.astype(object), noise_samples.astype(object)])
+
+    def model(X: np.ndarray) -> np.ndarray:
+        return causal_model.causal_mechanism(target_node).evaluate(X[:, :-noise_samples.shape[1]],
+                                                                   X[:, -noise_samples.shape[1]:])
+
+    shapley_vales = feature_relevance_distribution(model,
+                                                   feature_samples=samples_features,
+                                                   subset_scoring_func=subset_scoring_func,
+                                                   max_num_background_samples=num_background_samples,
+                                                   max_num_evaluation_samples=num_evaluation_samples,
+                                                   max_batch_size=max_batch_size,
+                                                   shapley_config=shapley_config)
+
+    result = {(predecessor, target_node): shapley_vales[i] for i, predecessor in enumerate(ordered_predecessors)}
+
+    return result, shapley_vales[-noise_samples.shape[1]:]
+
+
+def feature_relevance_distribution(prediction_method: Callable[[np.ndarray], np.ndarray],
+                                   feature_samples: np.ndarray,
+                                   subset_scoring_func:
+                                   Callable[[np.ndarray, np.ndarray], Union[np.ndarray, float]],
+                                   max_num_background_samples: int = 5000,
+                                   max_num_evaluation_samples: int = 500,
+                                   max_batch_size: int = 100,
+                                   randomize_features_jointly: bool = True,
+                                   shapley_config: Optional[ShapleyConfig] = None) -> np.ndarray:
+    """Estimates the population based feature relevance of the input features for the given prediction_method. This
+    method uses all samples given in feature_samples by comparing the output of the prediction_method given certain
+    features are randomized with the outputs when no features are randomized. The subset_scoring_func defines
+    how these predictions are compared. For instance, the variance of deviations.
+    
+    If the randomized predictions should rather be compared to the original data, this has (and can) be defined via
+    the set function by ignoring the second input parameter (the predicted values using all feauters). Instead, the
+    original data can be used.
+    
+    Note: The distribution level relevance is estimated by taking the expectation of the outcome of the set functions
+    when applied to multiple samples. Due to the linearity of the Shapley value estimation, this is equivalent to taking
+    the expectation over the Shapley values.
+
+    Related paper:
+    Janzing, D., Minorics, L., & Bloebaum, P. (2020).
+    Feature relevance quantification in explainable AI: A causal problem.
+    In International Conference on Artificial Intelligence and Statistics (pp. 2907-2916). PMLR.
+
+    :param prediction_method: A callable that is expected to return a prediction for given samples.
+    :param feature_samples: Samples from the joint distribution.
+    :param subset_scoring_func: Set function for estimating the quantity of interest based on the model outcomes. This function
+                                expects two inputs; the outcome of the prediction model for some samples if certain features are permuted and the
+                                outcome of the model for the same samples when no features were permuted. The set functions represents the
+                                comparison between the samples, for instance, the variance of deviations. This is then used as the 'characteristic function'
+                                in coalition games when estimating the Shapley values.
+    :param max_num_background_samples: Maximum number of samples used as background samples. Consider increasing this 
+                                       number for more accurate results (if enough samples are available) or reducing it for less memory consumption and 
+                                       faster runtime.
+    :param max_num_evaluation_samples: Maximum number of samples on which the set functions are evaluated on. 
+                                       For instance, in case of taking the mean as set_function_summary_func, this defines the maximum number of samples
+                                       used to estimate the mean. Consider increasing this number for more accurate results (if enough samples are 
+                                       available) or reducing it for less memory consumption and faster runtime.
+    :param max_batch_size: Maximum batch size for a estimating the predictions. This has a significant influence on the
+                           overall memory usage. If set to -1, all samples are used in one batch.
+    :param randomize_features_jointly: If set to True, features that are not in a subset are jointly permuted. 
+                                       Note that this still represents an interventional distribution. If set to False, features that are not in a subset 
+                                       are independently permuted. Note: The theory in the linked publication assumes that this is set to True.
+    :param shapley_config: Config for the Shapley estimator.
+    :return: A numpy array with the feature relevance of each input feature.
+    """
+    feature_samples = shape_into_2d(feature_samples)
+
+    if shapley_config is None:
+        shapley_config = ShapleyConfig()
+
+    samples_of_interest = feature_samples[np.random.choice(feature_samples.shape[0],
+                                                           min(max_num_evaluation_samples, feature_samples.shape[0]),
+                                                           replace=False)]
+    feature_samples = feature_samples[np.random.choice(feature_samples.shape[0],
+                                                       min(max_num_background_samples, feature_samples.shape[0]),
+                                                       replace=False)]
+
+    return feature_relevance_sample(prediction_method,
+                                    feature_samples,
+                                    samples_of_interest,
+                                    subset_scoring_func,
+                                    None,
+                                    True,
+                                    max_batch_size,
+                                    randomize_features_jointly,
+                                    shapley_config)
+
+
+def feature_relevance_sample(prediction_method: Callable[[np.ndarray], np.ndarray],
+                             feature_samples: np.ndarray,
+                             samples_of_interest: np.ndarray,
+                             subset_scoring_func: Callable[[np.ndarray, np.ndarray],
+                                                           Union[np.ndarray, float]],
+                             baseline_values: Optional[np.ndarray] = None,
+                             average_set_function: bool = False,
+                             max_batch_size: int = 100,
+                             randomize_features_jointly: bool = True,
+                             shapley_config: Optional[ShapleyConfig] = None) -> np.ndarray:
+    """Estimates the feature relevance of the prediction_method for each sample in samples_of_interest. This
+    method uses all samples given in feature_samples as 'background' samples. This is, they should represent samples
+    from the joint distribution of the input features. The subset_scoring_func defines the comparison between the
+    output of the prediction_method when certain features are randomized and the outputs when no features are
+    randomized. The most common function would be the difference between the expectations.
+
+    If the randomized predictions should rather be compared to the original data, this has (and can) be defined via
+    the set function by ignoring the second input parameter (the predicted values using all feauters). Instead, the
+    original data can be used.
+
+    Related paper:
+    Janzing, D., Minorics, L., & Bloebaum, P. (2020).
+    Feature relevance quantification in explainable AI: A causal problem.
+    In International Conference on Artificial Intelligence and Statistics (pp. 2907-2916). PMLR.
+
+    :param prediction_method: A callable that is expected to return a prediction for given samples.
+    :param feature_samples: Samples from the joint distribution. These are used as 'background samples'.
+    :param samples_of_interest: Samples for the feature relevance should be estimated.
+    :param subset_scoring_func: Set function for estimating the quantity of interest based on the model outcomes. This function
+                                expects two inputs; the outcome of the prediction model for some samples if certain features are permuted and the
+                                outcome of the model for the same samples when no features were permuted. A typical choice for regression models
+                                would be the difference between expectations. This is then used as the 'characteristic function'
+                                in coalition games when estimating the Shapley values.
+    :param baseline_values: These baseline values are compared with the subset specific outcomes of the prediction method. If set to None (default), the baseline values are the outcomes of the given prediction_method applied to the samples_of_interest, i.e. the outcome of the empty subset.
+    :param max_batch_size: Maximum batch size for a estimating the predictions. This has a significant influence on the
+                           overall memory usage. If set to -1, all samples are used in one batch.
+    :param average_set_function: If set to True, the averaged result of the set function applied to each sample of
+                                 interest is used for estimating the Shapley values. If set to False, Shapley values for each sample of interest
+                                 are estimated separately.
+    :param randomize_features_jointly: If set to True, features that are not in a subset are jointly permuted.
+                                       Note that this still represents an interventional distribution. If set to False, features that are not in a subset
+                                       are independently permuted. Note: The theory in the linked publication assumes that this is set to True.
+    :param shapley_config: Config for the Shapley estimator.
+    :return: A numpy array with the feature relevance for each sample in samples_of_interest.
+    """
+    feature_samples = shape_into_2d(feature_samples)
+    if baseline_values is None:
+        baseline_values = prediction_method(samples_of_interest)
+    else:
+        if samples_of_interest.shape[0] != baseline_values.shape[0]:
+            raise ValueError("Samples of interest and the given baseline values need to have the same sample size! "
+                             "Make sure that the given baseline values correspond to the samples of interest.")
+
+    if shapley_config is None:
+        shapley_config = ShapleyConfig()
+
+    def single_sample_set_function(subset: np.ndarray) -> Union[np.ndarray, float]:
+        results = np.zeros(baseline_values.shape[0])
+        predictions = marginal_expectation(prediction_method,
+                                           feature_samples=feature_samples,
+                                           samples_of_interest=samples_of_interest,
+                                           features_of_interest_indices=
+                                           np.arange(0, feature_samples.shape[1])[subset == 1],
+                                           return_averaged_results=False,
+                                           feature_perturbation='randomize_columns_jointly'
+                                           if randomize_features_jointly else 'randomize_columns_independently',
+                                           max_batch_size=max_batch_size)
+
+        for i in range(baseline_values.shape[0]):
+            results[i] = subset_scoring_func(predictions[i], baseline_values[i])
+
+        if average_set_function:
+            return np.mean(results)
+        else:
+            return results
+
+    return estimate_shapley_values(single_sample_set_function, feature_samples.shape[1], shapley_config)

--- a/dowhy/gcm/util/general.py
+++ b/dowhy/gcm/util/general.py
@@ -185,6 +185,20 @@ def means_difference(randomized_predictions: np.ndarray, baseline_values: np.nda
     return np.mean(randomized_predictions).squeeze() - np.mean(baseline_values).squeeze()
 
 
+def variance_of_deviations(randomized_predictions: np.ndarray, baseline_values: np.ndarray) -> np.ndarray:
+    # Using the negative value here seeing that the Shapley estimation evaluates v(S u {i}) - v(S) for a subset S. In
+    # case of variance, we have v(S u {i}) <= v(S), which would result in a negative contribution of players to the
+    # target quantity (here, variance).
+    return -np.var((randomized_predictions - baseline_values).squeeze())
+
+
+def variance_of_matching_values(randomized_predictions: np.ndarray, baseline_values: np.ndarray) -> np.ndarray:
+    # Using the negative value here seeing that the Shapley estimation evaluates v(S u {i}) - v(S) for a subset S. In
+    # case of variance, we have v(S u {i}) <= v(S), which would result in a negative contribution of players to the
+    # target quantity (here, variance).
+    return -np.var((randomized_predictions == baseline_values).squeeze())
+
+
 def geometric_median(x: np.ndarray) -> np.ndarray:
     def distance_function(x_input: np.ndarray) -> np.ndarray:
         return np.sum(np.sqrt(np.sum((x_input - x) ** 2, axis=1)))

--- a/tests/gcm/test_feature.py
+++ b/tests/gcm/test_feature.py
@@ -1,0 +1,255 @@
+import networkx as nx
+import numpy as np
+import pandas as pd
+from flaky import flaky
+from pytest import approx
+from scipy import stats
+
+from dowhy.gcm import auto, ClassifierFCM, AdditiveNoiseModel, ScipyDistribution, confidence_intervals, \
+    StructuralCausalModel, fit
+from dowhy.gcm.feature import parent_relevance, feature_relevance_sample, feature_relevance_distribution
+from dowhy.gcm.ml import create_logistic_regression_classifier, create_linear_regressor
+from dowhy.gcm.shapley import ShapleyConfig, ShapleyApproximationMethods
+from dowhy.gcm.uncertainty import estimate_entropy_of_probabilities
+from dowhy.gcm.util.general import means_difference
+
+
+@flaky(max_runs=5)
+def test_when_using_parent_relevance_with_continous_data_then_returns_correct_results():
+    causal_model = StructuralCausalModel(nx.DiGraph([('X1', 'X2'), ('X0', 'X2')]))
+    causal_model.set_causal_mechanism('X1', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X0', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X2', AdditiveNoiseModel(prediction_model=create_linear_regressor()))
+
+    X0 = np.random.normal(0, 1, 1000)
+    X1 = np.random.normal(0, 1, 1000)
+    training_data = pd.DataFrame({'X0': X0, 'X1': X1, 'X2': 3 * X0 + X1})
+
+    fit(causal_model, training_data)
+    relevance, noise = parent_relevance(causal_model, 'X2')
+
+    # Contributions should add up to Var(X2)
+    assert relevance[('X0', 'X2')] + relevance[('X1', 'X2')] + noise \
+           == approx(np.var(training_data['X2'].to_numpy()), abs=1.5)
+    assert relevance[('X0', 'X2')] == approx(9, abs=1)
+    assert relevance[('X1', 'X2')] == approx(1, abs=0.3)
+    assert noise == approx(0, abs=0.5)
+
+
+@flaky(max_runs=5)
+def test_when_using_parent_relevance_with_categorical_data_then_returns_correct_results():
+    causal_model = StructuralCausalModel(
+        nx.DiGraph([('X0', 'Y'), ('X1', 'Y'), ('X2', 'Y'), ('X3', 'Y'), ('X4', 'Y')]))
+    causal_model.set_causal_mechanism('X0', ScipyDistribution(stats.uniform, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X1', ScipyDistribution(stats.uniform, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X2', ScipyDistribution(stats.uniform, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X3', ScipyDistribution(stats.uniform, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X4', ScipyDistribution(stats.uniform, loc=0, scale=1))
+    causal_model.set_causal_mechanism('Y', ClassifierFCM())
+
+    X = np.random.uniform(0, 1, (1000, 5))
+    Y = []
+
+    for n in X:
+        if n[0] + n[1] > 1:
+            Y.append(0)
+        else:
+            Y.append(1)
+
+    X0 = X[:, 0]
+    X1 = X[:, 1]
+    X2 = X[:, 2]
+    X3 = X[:, 3]
+    X4 = X[:, 4]
+    Y = np.array(Y).astype(str)
+
+    fit(causal_model, data=pd.DataFrame({'X0': X0, 'X1': X1, 'X2': X2, 'X3': X3, 'X4': X4, 'Y': Y}))
+
+    relevance, noise = parent_relevance(causal_model, 'Y', num_background_samples=1000, num_evaluation_samples=100)
+
+    assert relevance[('X0', 'Y')] == approx(0.125, abs=0.05)
+    assert relevance[('X1', 'Y')] == approx(0.125, abs=0.05)
+    assert relevance[('X2', 'Y')] == approx(0, abs=0.05)
+    assert relevance[('X3', 'Y')] == approx(0, abs=0.05)
+    assert relevance[('X4', 'Y')] == approx(0, abs=0.05)
+    assert noise == approx(0, abs=0.05)
+
+
+@flaky(max_runs=5)
+def test_when_using_parent_relevance_with_confidence_intervals_then_returns_reasonable_bounds():
+    causal_model = StructuralCausalModel(nx.DiGraph([('X1', 'X2'), ('X0', 'X2')]))
+    causal_model.set_causal_mechanism('X1', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X0', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X2', AdditiveNoiseModel(prediction_model=create_linear_regressor()))
+
+    X0 = np.random.normal(0, 1, 1000)
+    X1 = np.random.normal(0, 1, 1000)
+
+    training_data = pd.DataFrame({'X0': X0,
+                                  'X1': X1,
+                                  'X2': 3 * X0 + X1})
+    fit(causal_model, training_data)
+
+    def estimation_func():
+        dict_result, noise = parent_relevance(causal_model, 'X2')
+        dict_result[('noise', 'X2')] = noise
+        return dict_result
+
+    median_relevance, cis = confidence_intervals(estimation_func, num_bootstrap_resamples=10)
+
+    # Contributions should add up to Var(X2)
+    assert median_relevance[('X0', 'X2')] == approx(9, abs=1)
+    assert median_relevance[('X1', 'X2')] == approx(1, abs=0.3)
+    assert median_relevance[('noise', 'X2')] == approx(0, abs=0.5)
+
+    assert cis[('X0', 'X2')] == approx(np.array([8.5, 9.5]), abs=1)
+    assert cis[('X1', 'X2')] == approx(np.array([0.8, 1.2]), abs=0.4)
+    assert cis[('noise', 'X2')] == approx(np.array([-0.2, 0.2]), abs=0.4)
+
+
+@flaky(max_runs=5)
+def test_feature_relevance_sample_mean_diff():
+    num_vars = 15
+    X = np.random.normal(0, 1, (1000, num_vars))
+    coefficients = np.random.choice(20, num_vars) - 10
+
+    def model(x) -> np.ndarray:
+        return np.sum(coefficients * x, axis=1)
+
+    shapley_values = feature_relevance_sample(model,
+                                              feature_samples=X,
+                                              samples_of_interest=X[:20],
+                                              subset_scoring_func=means_difference)
+
+    for i in range(20):
+        assert coefficients * (X[i, :] - np.mean(X, axis=0)) == approx(shapley_values[i], abs=0.001)
+
+
+@flaky(max_runs=3)
+def test_given_baseline_values_when_estimating_feature_relevance_sample_with_mean_diff_then_returns_expected_result():
+    num_vars = 5
+    X = np.random.normal(0, 1, (1000, num_vars))
+    coefficients = np.random.choice(20, num_vars) - 10
+
+    def model(x) -> np.ndarray:
+        return np.sum(coefficients * x, axis=1)
+
+    shapley_values_1 = \
+        feature_relevance_sample(model,
+                                 feature_samples=X,
+                                 samples_of_interest=X[:20],
+                                 subset_scoring_func=lambda x, y: np.mean(x) * y,
+                                 baseline_values=np.zeros(20),
+                                 shapley_config=ShapleyConfig(approximation_method=ShapleyApproximationMethods.EXACT))
+
+    shapley_values_2 = \
+        feature_relevance_sample(model,
+                                 feature_samples=X,
+                                 samples_of_interest=X[:20],
+                                 subset_scoring_func=lambda x, y: np.mean(x) * y,
+                                 baseline_values=np.zeros(20) + 1,
+                                 shapley_config=ShapleyConfig(approximation_method=ShapleyApproximationMethods.EXACT))
+
+    shapley_values_3 = \
+        feature_relevance_sample(model,
+                                 feature_samples=X,
+                                 samples_of_interest=X[:20],
+                                 subset_scoring_func=lambda x, y: np.mean(x) * y,
+                                 baseline_values=np.zeros(20) + 2,
+                                 shapley_config=ShapleyConfig(approximation_method=ShapleyApproximationMethods.EXACT))
+
+    for i in range(20):
+        assert shapley_values_1[i] == approx(np.zeros(5))
+        assert shapley_values_2[i] * 2 == approx(shapley_values_3[i])
+
+
+@flaky(max_runs=5)
+def test_feature_relevance_sample_mean_diff_with_certain_batch_size():
+    X = np.random.normal(0, 1, (1000, 3))
+    coefficients = np.random.choice(20, 3) - 10
+
+    def model(x) -> np.ndarray:
+        return np.sum(coefficients * x, axis=1)
+
+    shapley_values = feature_relevance_sample(model,
+                                              feature_samples=X,
+                                              samples_of_interest=X,
+                                              subset_scoring_func=means_difference,
+                                              max_batch_size=123)
+
+    for i in range(1000):
+        assert coefficients * (X[i, :] - np.mean(X, axis=0)) == approx(shapley_values[i], abs=0.001)
+
+
+@flaky(max_runs=3)
+def test_when_using_feature_relevance_distribution_with_entropy_set_function_then_returns_correct_results():
+    X = np.random.uniform(0, 1, (3000, 5))
+    Y = []
+
+    for n in X:
+        if n[0] + n[1] > 1:
+            Y.append(0)
+        else:
+            Y.append(1)
+
+    Y = np.array(Y).astype(str)
+
+    classifier_mdl = create_logistic_regression_classifier()
+    classifier_mdl.fit(X, Y)
+
+    # H(P(Y)) -- Can be precomputed
+    h_p_Y = estimate_entropy_of_probabilities(
+        np.mean(classifier_mdl.predict_probabilities(X), axis=0).reshape(1, -1))
+
+    # -(H(P(Y | do(x_S)) - H(P(Y))) = H(P(Y)) - H(P(Y | do(x_S))
+    def my_entropy_feature_attribution_function(randomized_predictions: np.ndarray,
+                                                baseline_predictions: np.ndarray) -> float:
+        # H(P(Y | do(x_S)) = H(E[P(Y | x_S, X'_\S)])
+
+        # E[P(Y | x_S, X'_\S)]
+        p_y_do_xs = np.mean(randomized_predictions, axis=0).reshape(1, -1)
+
+        # H(E[P(Y | x_S, X'_\S)])
+        h_p_Y_do_xs = estimate_entropy_of_probabilities(p_y_do_xs)
+
+        # Using H(P(Y)) based on the origina data, i.e. ignoring baseline_predictions.
+        return h_p_Y - h_p_Y_do_xs
+
+    feature_contributions = feature_relevance_distribution(classifier_mdl.predict_probabilities,
+                                                           X,
+                                                           my_entropy_feature_attribution_function)
+
+    # E[H(P(Y)) - H(P(Y | do(X_U))] = H(P(Y)) - E[H(P(Y | X))]
+    expected_sum_shapley_values = h_p_Y - estimate_entropy_of_probabilities(classifier_mdl.predict_probabilities(X))
+
+    assert feature_contributions[0] == approx(expected_sum_shapley_values / 2, abs=0.075)
+    assert feature_contributions[1] == approx(expected_sum_shapley_values / 2, abs=0.075)
+    assert feature_contributions[2] == approx(0, abs=0.01)
+    assert feature_contributions[3] == approx(0, abs=0.01)
+    assert feature_contributions[4] == approx(0, abs=0.01)
+
+    assert np.sum(feature_contributions) == approx(expected_sum_shapley_values, abs=0.04)
+
+
+@flaky(max_runs=3)
+def test_given_misspecified_graph_when_estimating_parent_relevance_with_observed_datas_then_returns_correct_result():
+    causal_model_without = StructuralCausalModel(nx.DiGraph([('X0', 'X2'), ('X1', 'X2')]))
+    causal_model_with = StructuralCausalModel(nx.DiGraph([('X0', 'X1'), ('X0', 'X2'), ('X1', 'X2')]))
+
+    X0 = np.random.normal(0, 1, 1000)
+    X1 = X0 + np.random.normal(0, 1, 1000)
+
+    training_data = pd.DataFrame({'X0': X0,
+                                  'X1': X1,
+                                  'X2': X0 + X1})
+    auto.assign_causal_mechanisms(causal_model_without, training_data, auto.AssignmentQuality.GOOD)
+    auto.assign_causal_mechanisms(causal_model_with, training_data, auto.AssignmentQuality.GOOD)
+
+    fit(causal_model_without, training_data)
+    fit(causal_model_with, training_data)
+
+    feature_relevance_missing_edge, _ = parent_relevance(causal_model_without, 'X2', training_data)
+    feature_relevance_with_edge, _ = parent_relevance(causal_model_with, 'X2')
+
+    assert feature_relevance_missing_edge[('X0', 'X2')] == approx(feature_relevance_with_edge[('X0', 'X2')], abs=0.1)
+    assert feature_relevance_missing_edge[('X1', 'X2')] == approx(feature_relevance_with_edge[('X1', 'X2')], abs=0.1)


### PR DESCRIPTION
This PR is depending on:
- https://github.com/py-why/dowhy/pull/433 
- https://github.com/py-why/dowhy/pull/438

Hence, feel free to skip modules `auto` and `confidence_intervals` when reviewing this.