### PR TITLE
Introduce GCM-based influence module

### DIFF
--- a/dowhy/gcm/__init__.py
+++ b/dowhy/gcm/__init__.py
@@ -9,6 +9,7 @@ from .confidence_intervals_cms import bootstrap_sampling, bootstrap_training_and
 from .fcms import PredictionModel, ClassificationModel, AdditiveNoiseModel, ClassifierFCM, PostNonlinearModel
 from .fitting_sampling import fit, draw_samples
 from .graph import StochasticModel, ConditionalStochasticModel, FunctionalCausalModel, DirectedGraph, is_root_node
+from .influence import arrow_strength, intrinsic_causal_influence
 from .stochastic_models import EmpiricalDistribution, BayesianGaussianMixtureDistribution, ScipyDistribution
 from .whatif import interventional_samples, counterfactual_samples
 from .distribution_change import distribution_change, distribution_change_of_graphs

--- a/dowhy/gcm/fcms.py
+++ b/dowhy/gcm/fcms.py
@@ -42,6 +42,7 @@ class ClassificationModel(PredictionModel):
     def predict_probabilities(self, X: np.array) -> np.ndarray:
         raise NotImplementedError
 
+    @property
     @abstractmethod
     def classes(self) -> List[str]:
         raise NotImplementedError
@@ -174,6 +175,7 @@ class AdditiveNoiseModel(PostNonlinearModel):
     Given joint samples from (X, Y), this model can be fitted by first training a model f (e.g. using least squares
     regression) and then reconstruct N by N = Y - f(X), i.e. using the residual.
     """
+
     def __init__(self,
                  prediction_model: PredictionModel,
                  noise_model: Optional[StochasticModel] = None) -> None:
@@ -206,6 +208,7 @@ class ClassifierFCM(FunctionalCausalModel, ProbabilityEstimatorModel):
     the noise is used to make this sampling process deterministic by using the cumulative distribution functions defined
     by the given inputs.
     """
+
     def __init__(self, classifier_model: Optional[ClassificationModel] = None) -> None:
         self._classifier_model = classifier_model
 
@@ -267,7 +270,7 @@ class ClassifierFCM(FunctionalCausalModel, ProbabilityEstimatorModel):
         return ClassifierFCM(classifier_model=self._classifier_model.clone())
 
     def get_class_names(self, class_indices: np.ndarray) -> List[str]:
-        return [self._classifier_model.classes()[index] for index in class_indices]
+        return [self._classifier_model.classes[index] for index in class_indices]
 
     @property
     def classifier_model(self) -> ClassificationModel:

--- a/dowhy/gcm/influence.py
+++ b/dowhy/gcm/influence.py
@@ -1,0 +1,335 @@
+"""This module provides functions to estimate causal influences.
+
+Functions in this module should be considered experimental, meaning there might be breaking API changes in the future.
+"""
+import logging
+import warnings
+from typing import Any, Union, Callable, Optional, Dict, Tuple, List, cast
+
+import numpy as np
+import pandas as pd
+from joblib import Parallel, delayed
+from numpy.matlib import repmat
+
+from dowhy.gcm._noise import noise_samples_of_ancestors, compute_data_from_noise
+from dowhy.gcm.cms import ProbabilisticCausalModel, StructuralCausalModel
+from dowhy.gcm.constant import EPS
+from dowhy.gcm.divergence import estimate_kl_divergence_of_probabilities
+from dowhy.gcm.fcms import ProbabilityEstimatorModel, PredictionModel, ClassificationModel, ClassifierFCM
+from dowhy.gcm.fitting_sampling import draw_samples
+from dowhy.gcm.graph import get_ordered_predecessors, is_root_node, node_connected_subgraph_view, \
+    ConditionalStochasticModel, validate_node, validate_causal_dag
+from dowhy.gcm.shapley import ShapleyConfig, estimate_shapley_values
+from dowhy.gcm.stats import marginal_expectation
+from dowhy.gcm.uncertainty import estimate_entropy_of_probabilities, estimate_variance
+from dowhy.gcm.util.general import shape_into_2d, set_random_seed, is_categorical
+
+_logger = logging.getLogger(__name__)
+
+
+def arrow_strength(causal_model: ProbabilisticCausalModel,
+                   target_node: Any,
+                   parent_samples: Optional[pd.DataFrame] = None,
+                   num_samples_conditional: int = 1000,
+                   max_num_runs: int = 5000,
+                   tolerance: float = 10 ** -4,
+                   n_jobs: int = 1,
+                   difference_estimation_func:
+                   Optional[Callable[[np.ndarray, np.ndarray], Union[np.ndarray, float]]] = None) \
+        -> Dict[Tuple[Any, Any], float]:
+    """Computes the causal strength of each edge directed to the target node.
+    The strength of an edge is quantified in terms of distance between conditional distributions of the target node in
+    the original graph and the imputed graph wherein the edge has been removed and the target node is fed a random
+    permutation of the observations of the source node. For more scientific details behind this API, please refer to
+    the research paper below.
+
+    **Research Paper**:
+    Dominik Janzing, David Balduzzi, Moritz Grosse-Wentrup, Bernhard Schölkopf. *Quantifying Causal Influences*. The
+    Annals of Statistics, Vol. 41, No. 5, 2324-2358, 2013.
+
+    :param causal_model: The probabilistic causal model for whose target node we compute the strength of incoming
+                         edges for.
+    :param target_node: The target node whose incoming edges' strength is to be computed.
+    :param num_samples_conditional: Sample size to use for estimating the distance between distributions.
+    :param max_num_runs: The maximum number of times to resample and estimate the strength to report the average
+                         strength.
+    :param tolerance: The difference in average strength between two successive runs to terminate early without
+                      running it max_num_runs times.
+    :param n_jobs: The number of jobs to run in parallel. Set it to -1 to use all processors.
+    :param difference_estimation_func: Optional: How to measure the distance between two distributions. By default,
+                                       the expectation of squared differences is estimated for a continuous target node
+                                       and the KL divergence for a categorical target node.
+    :return: Causal strength of each edge.
+    """
+    if target_node not in causal_model.graph.nodes:
+        raise ValueError("Target node %s can not be found in given graph!" % target_node)
+    if is_root_node(causal_model.graph, target_node):
+        raise ValueError("Target node %s is a root node, but it requires to have ancestors!" % target_node)
+
+    sub_causal_model = ProbabilisticCausalModel(node_connected_subgraph_view(causal_model.graph, target_node))
+    validate_node(sub_causal_model.graph, target_node)
+
+    ordered_predecessors = get_ordered_predecessors(sub_causal_model.graph, target_node)
+
+    if parent_samples is None:
+        parent_samples = draw_samples(sub_causal_model, num_samples_conditional * 10)[ordered_predecessors]
+
+    direct_influences = arrow_strength_of_model(sub_causal_model.causal_mechanism(target_node),
+                                                parent_samples[ordered_predecessors].to_numpy(),
+                                                num_samples_from_conditional=num_samples_conditional,
+                                                max_num_runs=max_num_runs,
+                                                tolerance=tolerance,
+                                                n_jobs=n_jobs,
+                                                difference_estimation_func=difference_estimation_func)
+    return {(predecessor, target_node): direct_influences[i] for i, predecessor in enumerate(ordered_predecessors)}
+
+
+def arrow_strength_of_model(conditional_stochastic_model: ConditionalStochasticModel,
+                            input_samples: np.ndarray,
+                            num_samples_from_conditional: int = 1000,
+                            max_num_runs: int = 5000,
+                            tolerance: float = 10 ** -4,
+                            n_jobs: int = 1,
+                            difference_estimation_func:
+                            Optional[Callable[[np.ndarray, np.ndarray], Union[np.ndarray, float]]] = None,
+                            input_subsets: Optional[List[List[int]]] = None) -> np.ndarray:
+    input_samples = shape_into_2d(input_samples)
+
+    if input_subsets is None:
+        input_subsets = [[i] for i in range(input_samples.shape[1])]
+
+    if difference_estimation_func is None:
+        if isinstance(conditional_stochastic_model, ProbabilityEstimatorModel):
+            difference_estimation_func = estimate_kl_divergence_of_probabilities
+        else:
+            def difference_estimation_func(old, new):
+                return (np.mean(new) - np.mean(old)).squeeze() ** 2
+
+    if isinstance(conditional_stochastic_model, ProbabilityEstimatorModel):
+        samples_creation_method = conditional_stochastic_model.estimate_probabilities
+    else:
+        samples_creation_method = conditional_stochastic_model.draw_samples
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore')
+
+        def parallel_job(subset: List[int],
+                         parallel_random_seed: int):
+            set_random_seed(parallel_random_seed)
+
+            return _estimate_direct_strength(
+                samples_creation_method,
+                input_samples,
+                subset,
+                difference_estimation_func,
+                num_samples_from_conditional,
+                max_num_runs,
+                tolerance)
+
+        random_seeds = np.random.randint(np.iinfo(np.int32).max, size=len(input_subsets))
+        results = Parallel(n_jobs=n_jobs)(delayed(parallel_job)(subset, random_seed)
+                                          for subset, random_seed in zip(input_subsets, random_seeds))
+
+    if np.any(results == np.inf):
+        _logger.warning('At least one arrow strength is infinite. This typically happens if the causal models are '
+                        'deterministic, i.e. there is no noise or it is extremely small.')
+
+    return np.array(results)
+
+
+def _estimate_direct_strength(draw_samples_func: Callable[[np.ndarray], np.ndarray],
+                              distribution_samples: np.ndarray,
+                              target_columns: List[int],
+                              difference_estimation_func:
+                              Callable[[np.ndarray, np.ndarray], Union[np.ndarray, float]],
+                              num_samples_conditional: int,
+                              max_num_runs: int,
+                              tolerance: float) -> float:
+    distribution_samples = shape_into_2d(distribution_samples)
+
+    aggregated_conditional_difference_result = 0
+    average_difference_result = 0
+    converged_run = 0
+    for run, sample in enumerate(distribution_samples):
+        tmp_samples = repmat(sample, num_samples_conditional, 1)
+
+        rnd_permutation = np.random.choice(distribution_samples.shape[0],
+                                           num_samples_conditional,
+                                           replace=False)
+
+        removed_arrow_sampling = shape_into_2d(distribution_samples[:, target_columns][rnd_permutation])
+        conditional_distribution_samples = draw_samples_func(tmp_samples)
+        tmp_samples[:, target_columns] = removed_arrow_sampling
+        cond_dist_removed_arr_samples = draw_samples_func(tmp_samples)
+
+        old_average_difference_result = average_difference_result
+
+        aggregated_conditional_difference_result += difference_estimation_func(conditional_distribution_samples,
+                                                                               cond_dist_removed_arr_samples)
+
+        average_difference_result = aggregated_conditional_difference_result / (run + 1)
+
+        if run >= max_num_runs:
+            break
+        elif run > 0:
+            if old_average_difference_result == 0:
+                old_average_difference_result = EPS
+
+            if abs(1 - average_difference_result / old_average_difference_result) < tolerance:
+                converged_run += 1
+                if converged_run >= 3:
+                    break
+            else:
+                converged_run = 0
+
+    return average_difference_result
+
+
+def intrinsic_causal_influence(causal_model: StructuralCausalModel,
+                               target_node: Any,
+                               prediction_model: Union[PredictionModel, ClassificationModel, str] = 'exact',
+                               attribution_func: Optional[Callable[[np.ndarray, np.ndarray], float]] = None,
+                               num_training_samples: int = 100000,
+                               num_noise_samples: int = 7500,
+                               num_evaluation_samples: int = 1000,
+                               max_batch_size: int = 100,
+                               approx_select_model: Callable[[np.ndarray, np.ndarray],
+                                                             Union[PredictionModel, ClassificationModel]] = None,
+                               shapley_config: Optional[ShapleyConfig] = None) -> Dict[Any, float]:
+    """Computes the causal contribution of each noise term in the functional causal model to the statistical property
+    (e.g. mean, variance) of the target node. We call this contribution *instrinsic* as noise terms, by definition,
+    do not inherit properties of observed parents. The contribution of each noise term is then the *intrinsic*
+    causal contribution of the corresponding node. For more scientific details, please refer to the paper below.
+
+    **Research Paper**:
+    Janzing et al. *Quantifying causal contributions via structure preserving interventions*. arXiv:2007.00714, 2021.
+
+    :param causal_model: The structural causal model for whose target node we compute the intrinsic causal influence
+                         of its ancestors.
+    :param target_node: Target node whose statistical property is to be attributed.
+    :param prediction_model: Prediction model for estimating the functional relationship between subsets of ancestor
+                             noise terms and the target node. This can be an instance of a PredictionModel, the string
+                             'approx' or the string 'exact'. With 'exact', the underlying causal models in the graph
+                             are utilized directly by propagating given noise inputs through the graph. This is
+                             generally more accurate but slow. With 'approx', an appropriate model is selected and
+                             trained based on sampled data from the graph, which is less accurate but faster. A more
+                             detailed treatment on why we need this parameter is also provided in :ref:`icc`.
+    :param attribution_func: Optional attribution function to measure the statistical property of the target node. This
+                             function expects two inputs; predictions after the randomization of certain features (i.e.
+                             samples from noise nodes) and a baseline where no features were randomized. The baseline
+                             predictions can be typically ignored if one is interested in uncertainty measures such as
+                             entropy or variance, but they might be relevant if, for instance, these shall be estimated
+                             based on the residuals. By default, entropy is used if prediction model is a classifier,
+                             variance otherwise.
+    :param num_training_samples: Number of samples for fitting the prediction_model. This number should be larger
+                                 than num_noise_samples + num_evaluation_samples.
+    :param num_noise_samples: Size of noise samples of upstream noise terms (of the target node) to draw from the
+                              causal graph. These will be used as background samples.
+    :param num_evaluation_samples: Size of noise samples to use in computing intrinsic causal contribution. These
+                                   will be used as samples of interest.
+    :param max_batch_size: Maximum batch size for estimating the predictions from evaluation samples. This has a
+                           significant impact on the overall memory usage. If set to -1, all samples are used in one
+                           batch.
+    :param approx_select_model: Optional function to select the prediction_model when prediction_model is set to
+                                'approx'. If not provided, defaults to auto.select_model().
+    :param shapley_config: Configuration for the Shapley estimator.
+    :return: Intrinsic causal contribution of each ancestor node to the statistical property defined by the
+             attribution_func of the target node.
+    """
+    validate_causal_dag(causal_model.graph)
+
+    reduced_causal_model = StructuralCausalModel(node_connected_subgraph_view(causal_model.graph, target_node))
+
+    data_samples, noise_samples = \
+        noise_samples_of_ancestors(reduced_causal_model,
+                                   target_node,
+                                   max(num_training_samples, num_noise_samples + num_evaluation_samples))
+    node_names = noise_samples.columns
+    noise_samples, target_samples = shape_into_2d(noise_samples.to_numpy(),
+                                                  data_samples[target_node].to_numpy())
+
+    target_is_categorical = is_categorical(data_samples[target_node].to_numpy())
+
+    if prediction_model == 'approx':
+        if approx_select_model is None:
+            from dowhy.gcm import auto
+            prediction_model = auto.select_model(noise_samples, target_samples, auto.AssignmentQuality.GOOD)
+        else:
+            prediction_model = approx_select_model(noise_samples, target_samples)
+        prediction_model.fit(noise_samples, target_samples)
+
+        if target_is_categorical:
+            prediction_method = prediction_model.predict_probabilities
+        else:
+            prediction_method = prediction_model.predict
+    elif prediction_model == 'exact':
+        def exact_model(X: np.ndarray) -> np.ndarray:
+            return compute_data_from_noise(reduced_causal_model,
+                                           pd.DataFrame(X, columns=[x for x in node_names]))[target_node].to_numpy()
+
+        if target_is_categorical:
+            list_of_classes = \
+                cast(ClassifierFCM, reduced_causal_model.causal_mechanism(target_node)).classifier_model.classes
+
+            def prediction_method(X):
+                return (shape_into_2d(exact_model(X)) == list_of_classes).astype(float)
+        else:
+            prediction_method = exact_model
+    elif isinstance(prediction_model, str):
+        raise ValueError(
+            "Invalid value for prediction_model: %s! This should either be an instance of a PredictionModel or"
+            "one of the two string options 'exact' or 'approx'." % prediction_model)
+    else:
+        prediction_model.fit(noise_samples, target_samples)
+        prediction_method = prediction_model.predict
+
+    if attribution_func is None:
+        if target_is_categorical:
+            def attribution_func(x, _):
+                return -estimate_entropy_of_probabilities(x)
+        else:
+            def attribution_func(x, _):
+                return estimate_variance(x)
+
+    iccs = _estimate_iccs(attribution_func,
+                          prediction_method,
+                          noise_samples[:num_noise_samples],
+                          noise_samples[num_noise_samples:num_noise_samples + num_evaluation_samples],
+                          max_batch_size,
+                          ShapleyConfig() if shapley_config is None else shapley_config)
+
+    return {node: iccs[i] for i, node in enumerate(node_names)}
+
+
+def _estimate_iccs(attribution_func: Callable[[np.ndarray, np.ndarray], float],
+                   prediction_method: Callable[[np.ndarray], np.ndarray],
+                   noise_samples: np.ndarray,
+                   samples_of_interest: np.ndarray,
+                   max_batch_size: int,
+                   shapley_config: ShapleyConfig):
+    target_values = shape_into_2d(prediction_method(samples_of_interest))
+
+    def icc_set_function(subset: np.ndarray) -> Union[np.ndarray, float]:
+        if np.all(subset == 1):
+            # In case of the full subset (no randomization), we get the same predictions as when we apply the
+            # prediction method to the samples of interest, since all noise samples are replaced with a sample of
+            # interest.
+            predictions = target_values
+        elif np.all(subset == 0):
+            # In case of the empty subset (all are jointly randomize), it boils down to taking the average over all
+            # predictions, seeing that the randomization yields the same values for each sample of interest (none of the
+            # samples of interest are used to replace a (jointly) 'randomized' sample).
+            predictions = \
+                repmat(np.mean(prediction_method(noise_samples), axis=0), samples_of_interest.shape[0], 1)
+        else:
+            predictions = marginal_expectation(prediction_method,
+                                               feature_samples=noise_samples,
+                                               samples_of_interest=samples_of_interest,
+                                               features_of_interest_indices=
+                                               np.arange(0, noise_samples.shape[1])[subset == 1],
+                                               return_averaged_results=True,
+                                               feature_perturbation='randomize_columns_jointly',
+                                               max_batch_size=max_batch_size)
+        return attribution_func(shape_into_2d(predictions), target_values)
+
+    return estimate_shapley_values(icc_set_function, noise_samples.shape[1], shapley_config)

--- a/dowhy/gcm/influence.py
+++ b/dowhy/gcm/influence.py
@@ -50,6 +50,10 @@ def arrow_strength(causal_model: ProbabilisticCausalModel,
     :param causal_model: The probabilistic causal model for whose target node we compute the strength of incoming
                          edges for.
     :param target_node: The target node whose incoming edges' strength is to be computed.
+    :param parent_samples: Optional samples from the parents of the target_node. If None are given, they are generated
+                           based on the provided causal model. Providing observational data can help to mitigate
+                           misspecifications in the graph, such as missing interactions between root nodes or 
+                           confounders.
     :param num_samples_conditional: Sample size to use for estimating the distance between distributions.
     :param max_num_runs: The maximum number of times to resample and estimate the strength to report the average
                          strength.
@@ -57,7 +61,7 @@ def arrow_strength(causal_model: ProbabilisticCausalModel,
                       running it max_num_runs times.
     :param n_jobs: The number of jobs to run in parallel. Set it to -1 to use all processors.
     :param difference_estimation_func: Optional: How to measure the distance between two distributions. By default,
-                                       the expectation of squared differences is estimated for a continuous target node
+                                       the difference of the variance is estimated for a continuous target node
                                        and the KL divergence for a categorical target node.
     :return: Causal strength of each edge.
     """
@@ -103,7 +107,7 @@ def arrow_strength_of_model(conditional_stochastic_model: ConditionalStochasticM
             difference_estimation_func = estimate_kl_divergence_of_probabilities
         else:
             def difference_estimation_func(old, new):
-                return (np.mean(new) - np.mean(old)).squeeze() ** 2
+                return np.var(new) - np.var(old)
 
     if isinstance(conditional_stochastic_model, ProbabilityEstimatorModel):
         samples_creation_method = conditional_stochastic_model.estimate_probabilities

--- a/dowhy/gcm/ml/classification.py
+++ b/dowhy/gcm/ml/classification.py
@@ -30,6 +30,7 @@ class SklearnClassificationModel(SklearnRegressionModel, ClassificationModel):
         return shape_into_2d(
             self._sklearn_mdl.predict_proba(apply_one_hot_encoding(X, self._one_hot_encoders)))
 
+    @property
     def classes(self) -> List[str]:
         return self._sklearn_mdl.classes_
 

--- a/tests/gcm/test_arrow_strength.py
+++ b/tests/gcm/test_arrow_strength.py
@@ -1,0 +1,114 @@
+import random
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pytest
+from flaky import flaky
+from pytest import approx
+from scipy import stats
+
+from dowhy.gcm import ClassifierFCM, AdditiveNoiseModel, ProbabilisticCausalModel, fit, arrow_strength, \
+    ScipyDistribution
+from dowhy.gcm.divergence import estimate_kl_divergence_continuous
+from dowhy.gcm.influence import arrow_strength_of_model
+from dowhy.gcm.ml import create_logistic_regression_classifier, create_linear_regressor
+
+
+@pytest.fixture
+def preserve_random_generator_state():
+    numpy_state = np.random.get_state()
+    random_state = random.getstate()
+    yield
+    np.random.set_state(numpy_state)
+    random.setstate(random_state)
+
+
+@flaky(max_runs=5)
+def test_given_kl_divergence_attribution_func_when_estimate_arrow_strength_then_returns_expected_results():
+    causal_model = ProbabilisticCausalModel(nx.DiGraph([('X1', 'X2'), ('X0', 'X2')]))
+    causal_model.set_causal_mechanism('X1', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X0', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X2', AdditiveNoiseModel(prediction_model=create_linear_regressor()))
+
+    X0 = np.random.normal(0, 1, 1000)
+    X1 = np.random.normal(0, 1, 1000)
+
+    test_data = pd.DataFrame({'X0': X0,
+                              'X1': X1,
+                              'X2': 3 * X0 + X1 + np.random.normal(0, 0.2, X0.shape[0])})
+    fit(causal_model, test_data)
+
+    causal_strengths = arrow_strength(causal_model,
+                                      'X2',
+                                      difference_estimation_func=estimate_kl_divergence_continuous)
+    assert causal_strengths[('X0', 'X2')] == approx(2.76, abs=0.4)
+    assert causal_strengths[('X1', 'X2')] == approx(1.6, abs=0.4)
+
+
+@flaky(max_runs=5)
+def test_given_continuous_data_with_default_atttribution_func_when_estimate_arrow_strength_then_returns_expected_results():
+    causal_model = ProbabilisticCausalModel(nx.DiGraph([('X1', 'X2'), ('X0', 'X2')]))
+    causal_model.set_causal_mechanism('X1', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X0', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X2', AdditiveNoiseModel(
+        prediction_model=create_linear_regressor()))
+
+    X0 = np.random.normal(0, 1, 1000)
+    X1 = np.random.normal(0, 1, 1000)
+
+    test_data = pd.DataFrame({'X0': X0,
+                              'X1': X1,
+                              'X2': 3 * X0 + X1 + np.random.normal(0, 0.2, X0.shape[0])})
+    fit(causal_model, test_data)
+
+    causal_strengths = arrow_strength(causal_model, 'X2', tolerance=10 ** -4)
+    assert causal_strengths[('X0', 'X2')] == approx(9, abs=0.5)
+    assert causal_strengths[('X1', 'X2')] == approx(1, abs=0.2)
+
+
+@flaky(max_runs=5)
+def test_arrow_strength_with_squared_mean_difference():
+    causal_model = ProbabilisticCausalModel(nx.DiGraph([('X1', 'X2'), ('X0', 'X2')]))
+    causal_model.set_causal_mechanism('X1', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X0', ScipyDistribution(stats.norm, loc=0, scale=1))
+    causal_model.set_causal_mechanism('X2', AdditiveNoiseModel(prediction_model=create_linear_regressor()))
+
+    X0 = np.random.normal(0, 1, 1000)
+    X1 = np.random.normal(0, 1, 1000)
+
+    test_data = pd.DataFrame({'X0': X0,
+                              'X1': X1,
+                              'X2': 2 * X0 + X1 + np.random.normal(0, 0.2, X0.shape[0])})
+    fit(causal_model, test_data)
+
+    causal_strengths \
+        = arrow_strength(causal_model, 'X2', tolerance=10 ** -5,
+                         difference_estimation_func=lambda x, y:
+                         (np.mean(x).squeeze() - np.mean(y).squeeze()) ** 2)
+    assert causal_strengths[('X0', 'X2')] == approx(4, abs=0.4)
+    assert causal_strengths[('X1', 'X2')] == approx(1, abs=0.4)
+
+    causal_strengths \
+        = arrow_strength(causal_model, 'X2', tolerance=10 ** -5,
+                         difference_estimation_func=lambda x, y:
+                         (np.mean(x).squeeze() - np.mean(y).squeeze()) ** 2)
+    assert causal_strengths[('X0', 'X2')] == approx(4, abs=0.4)
+    assert causal_strengths[('X1', 'X2')] == approx(1, abs=0.4)
+
+
+@flaky(max_runs=5)
+def test_arrow_strength_of_model_classifier():
+    X = np.random.random((1000, 5))
+    Y = []
+
+    for n in X:
+        if (n[0] + n[1] + np.random.random(1)) > 1.5:
+            Y.append(0)
+        else:
+            Y.append(1)
+
+    classifier_sem = ClassifierFCM(create_logistic_regression_classifier())
+    classifier_sem.fit(X, np.array(Y).astype(str))
+
+    assert arrow_strength_of_model(classifier_sem, X) == approx(np.array([0.3, 0.3, 0, 0, 0]), abs=0.1)

--- a/tests/gcm/test_arrow_strength.py
+++ b/tests/gcm/test_arrow_strength.py
@@ -121,8 +121,8 @@ def test_given_gcm_with_misspecified_mechanism_when_evaluate_arrow_strength_with
     causal_model.set_causal_mechanism('X1', ScipyDistribution(stats.norm, loc=0, scale=1))
     causal_model.set_causal_mechanism('X2', AdditiveNoiseModel(prediction_model=create_linear_regressor()))
 
-    X0 = np.random.normal(0, 2, 1000)  # The standard deviation in the data is actually 2.
-    X1 = np.random.normal(0, 1, 1000)
+    X0 = np.random.normal(0, 2, 2000)  # The standard deviation in the data is actually 2.
+    X1 = np.random.normal(0, 1, 2000)
 
     test_data = pd.DataFrame({'X0': X0,
                               'X1': X1,
@@ -135,7 +135,7 @@ def test_given_gcm_with_misspecified_mechanism_when_evaluate_arrow_strength_with
                          'X2',
                          parent_samples=test_data,
                          difference_estimation_func=lambda x, y: np.var(y) - np.var(x))
-    assert causal_strengths[('X0', 'X2')] == approx(4, abs=0.1)
+    assert causal_strengths[('X0', 'X2')] == approx(4, abs=0.5)
     assert causal_strengths[('X1', 'X2')] == approx(1, abs=0.1)
 
 

--- a/tests/gcm/test_intrinsic_influence.py
+++ b/tests/gcm/test_intrinsic_influence.py
@@ -1,0 +1,195 @@
+import networkx as nx
+import numpy as np
+import pandas as pd
+from flaky import flaky
+from pytest import approx
+from sklearn.linear_model import LogisticRegression
+
+from dowhy.gcm import auto, fit, intrinsic_causal_influence, StructuralCausalModel
+from dowhy.gcm._noise import noise_samples_of_ancestors
+from dowhy.gcm.graph import node_connected_subgraph_view
+from dowhy.gcm.ml import create_hist_gradient_boost_classifier
+from dowhy.gcm.uncertainty import estimate_variance, estimate_entropy_of_probabilities
+from dowhy.gcm.util.general import apply_one_hot_encoding, fit_one_hot_encoders
+
+
+@flaky(max_runs=3)
+def test_intrinsic_causal_influence_variance_linear():
+    causal_model = StructuralCausalModel(nx.DiGraph([('X0', 'X1'), ('X1', 'X2'), ('X2', 'X3')]))
+
+    X0 = np.random.normal(0, 1, 10000)
+    X1 = X0 + np.random.normal(0, 0.001, 10000)
+    X2 = X1 + np.random.normal(0, 2, 10000)
+    X3 = X2 + np.random.normal(0, 1, 10000)
+    training_data = pd.DataFrame({'X0': X0, 'X1': X1, 'X2': X2, 'X3': X3})
+    auto.assign_causal_mechanisms(causal_model, training_data, auto.AssignmentQuality.GOOD)
+
+    fit(causal_model, training_data)
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx')
+    assert iccs['X0'] == approx(1, abs=0.25)
+    assert iccs['X1'] == approx(0, abs=0.05)
+    assert iccs['X2'] == approx(4, abs=0.5)
+    assert iccs['X3'] == approx(1, abs=0.25)
+    assert np.sum([iccs[key] for key in iccs]) == approx(estimate_variance(X3), abs=0.5)
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact')
+    assert iccs['X0'] == approx(1, abs=0.25)
+    assert iccs['X1'] == approx(0, abs=0.05)
+    assert iccs['X2'] == approx(4, abs=0.5)
+    assert iccs['X3'] == approx(1, abs=0.25)
+    assert np.sum([iccs[key] for key in iccs]) == approx(estimate_variance(X3), abs=0.5)
+
+
+@flaky(max_runs=3)
+def test_intrinsic_causal_influence_categorical():
+    causal_model = StructuralCausalModel(nx.DiGraph([('X0', 'X1'), ('X1', 'X2'), ('X2', 'X3')]))
+
+    N1 = np.random.normal(0, 0.001, 10000)
+    N2 = np.random.normal(0, 2, 10000)
+    N3 = np.random.normal(0, 1, 10000)
+    X0 = np.random.normal(0, 1, 10000)
+    X1 = X0 + N1
+    X2 = X1 + N2
+    X3 = ((X2 + N3) >= 0).astype(str)
+    training_data = pd.DataFrame({'X0': X0, 'X1': X1, 'X2': X2, 'X3': X3})
+    auto.assign_causal_mechanisms(causal_model, training_data, auto.AssignmentQuality.GOOD)
+
+    fit(causal_model, training_data)
+
+    log_mdl = LogisticRegression(max_iter=1000)
+    log_mdl.fit(np.column_stack([X0, N1, N2, N3]), X3)
+
+    expected_output_full_subset = \
+        -estimate_entropy_of_probabilities(log_mdl.predict_proba(np.column_stack([X0, N1, N2, N3])))
+    expected_output_empty_subset = -estimate_entropy_of_probabilities(np.array([[0.5, 0.5]]))
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_evaluation_samples=100)
+    assert iccs['X0'] == approx(0.14, abs=0.05)
+    assert iccs['X1'] == approx(0.01, abs=0.05)
+    assert iccs['X2'] == approx(0.38, abs=0.05)
+    assert iccs['X3'] == approx(0.12, abs=0.05)
+
+    assert np.sum([iccs[key] for key in iccs]) == approx(expected_output_full_subset - expected_output_empty_subset,
+                                                         abs=0.05)
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_evaluation_samples=100)
+    assert iccs['X0'] == approx(0.14, abs=0.05)
+    assert iccs['X1'] == approx(0.01, abs=0.05)
+    assert iccs['X2'] == approx(0.38, abs=0.05)
+    assert iccs['X3'] == approx(0.12, abs=0.05)
+
+    assert np.sum([iccs[key] for key in iccs]) == approx(-expected_output_empty_subset, abs=0.05)
+
+
+@flaky(max_runs=3)
+def test_intrinsic_causal_influence_categorical_2():
+    causal_model = StructuralCausalModel(nx.DiGraph([('X0', 'X1'), ('X1', 'X2'), ('X2', 'X3')]))
+    N1 = np.random.normal(0, 0.001, 10000)
+    N2 = np.random.normal(0, 2, 10000)
+    X0 = np.random.normal(0, 1, 10000)
+    X1 = X0 + N1
+    X2 = X1 + N2
+
+    X3 = []
+    for i in range(10000):
+        rand_val = np.random.choice(3, 1).squeeze()
+        if rand_val == 0:
+            X3.append(X2[i] + np.random.normal(-5, 0.5, 1))
+        elif rand_val == 1:
+            X3.append(X2[i] + np.random.normal(10, 0.5, 1))
+        else:
+            X3.append(X2[i] + np.random.normal(5, 0.5, 1))
+
+    X3 = np.array(X3)
+    X3 = (X3 > np.median(X3)).astype(str)
+    training_data = pd.DataFrame({'X0': X0, 'X1': X1, 'X2': X2, 'X3': X3.reshape(-1)})
+    auto.assign_causal_mechanisms(causal_model, training_data, auto.AssignmentQuality.GOOD)
+
+    fit(causal_model, training_data)
+
+    data_samples, noise_samples = noise_samples_of_ancestors(
+        StructuralCausalModel(node_connected_subgraph_view(causal_model.graph, 'X3')),
+        'X3',
+        100000)
+    X = apply_one_hot_encoding(noise_samples.to_numpy(), fit_one_hot_encoders(noise_samples.to_numpy()))
+    log_mdl = LogisticRegression()
+    log_mdl.fit(X, data_samples['X3'].to_numpy())
+
+    expected_output_full_subset = -estimate_entropy_of_probabilities(log_mdl.predict_proba(X))
+    expected_output_empty_subset = -estimate_entropy_of_probabilities(np.array([[0.5, 0.5]]))
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_evaluation_samples=100)
+    assert iccs['X0'] == approx(0.05, abs=0.05)
+    assert iccs['X1'] == approx(0.03, abs=0.05)
+    assert iccs['X2'] == approx(0.1, abs=0.05)
+    assert iccs['X3'] == approx(0.5, abs=0.05)
+
+    assert np.sum([iccs[key] for key in iccs]) == approx(expected_output_full_subset - expected_output_empty_subset,
+                                                         abs=0.05)
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_evaluation_samples=100)
+    assert iccs['X0'] == approx(0.05, abs=0.05)
+    assert iccs['X1'] == approx(0.03, abs=0.05)
+    assert iccs['X2'] == approx(0.1, abs=0.05)
+    assert iccs['X3'] == approx(0.5, abs=0.05)
+
+    assert np.sum([iccs[key] for key in iccs]) == approx(-expected_output_empty_subset, abs=0.05)
+
+
+@flaky(max_runs=3)
+def test_given_only_categorical_data_when_estimate_icc_then_does_not_fail():
+    causal_model = StructuralCausalModel(nx.DiGraph([('X0', 'X1'), ('X1', 'X2'), ('X2', 'X3')]))
+    X0 = np.random.normal(0, 1, 10000)
+    X1 = X0 + np.random.normal(0, 0.001, 10000)
+    X2 = X1 + np.random.normal(0, 2, 10000)
+    X3 = ((X2 + np.random.normal(0, 1, 10000)) >= 0).astype(str)
+    training_data = pd.DataFrame({'X0': (X0 >= 0).astype(str),
+                                  'X1': (X1 >= 0).astype(str),
+                                  'X2': (X2 >= 0).astype(str),
+                                  'X3': X3})
+    auto.assign_causal_mechanisms(causal_model, training_data, auto.AssignmentQuality.GOOD)
+
+    fit(causal_model, training_data)
+
+    data_samples, noise_samples = noise_samples_of_ancestors(
+        StructuralCausalModel(node_connected_subgraph_view(causal_model.graph, 'X3')), 'X3', 100000)
+    X = apply_one_hot_encoding(noise_samples.to_numpy(), fit_one_hot_encoders(noise_samples.to_numpy()))
+    log_mdl = create_hist_gradient_boost_classifier()  # Due to the categorical features, this becomes non-linear.
+    log_mdl.fit(X, data_samples['X3'].to_numpy())
+
+    expected_output_full_subset = -estimate_entropy_of_probabilities(log_mdl.predict_probabilities(X))
+    expected_output_empty_subset = -estimate_entropy_of_probabilities(np.array([[0.5, 0.5]]))
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_evaluation_samples=100)
+    assert iccs['X0'] == approx(0.08, abs=0.03)
+    assert iccs['X1'] == approx(0, abs=0.005)
+    assert iccs['X2'] == approx(0.33, abs=0.05)
+    assert iccs['X3'] == approx(0.27, abs=0.05)
+
+    assert np.sum([iccs[key] for key in iccs]) == approx(expected_output_full_subset - expected_output_empty_subset,
+                                                         abs=0.05)
+
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_evaluation_samples=100)
+    assert iccs['X0'] == approx(0.08, abs=0.03)
+    assert iccs['X1'] == approx(0, abs=0.005)
+    assert iccs['X2'] == approx(0.33, abs=0.05)
+    assert iccs['X3'] == approx(0.27, abs=0.05)
+
+    assert np.sum([iccs[key] for key in iccs]) == approx(-expected_output_empty_subset, abs=0.05)
+
+
+def test_when_calling_intrinsic_causal_influence_then_the_shape_of_inputs_in_the_attribution_function_should_be_equal():
+    causal_model = StructuralCausalModel(nx.DiGraph([('X0', 'X1')]))
+    X0 = np.random.normal(0, 1, 10000)
+    X1 = X0 + np.random.normal(0, 0.001, 10000)
+    training_data = pd.DataFrame({'X0': X0, 'X1': X1})
+    auto.assign_causal_mechanisms(causal_model, training_data, auto.AssignmentQuality.GOOD)
+
+    fit(causal_model, training_data)
+
+    def my_attr_func(X, Y):
+        assert np.all(X.shape == Y.shape)
+        return 0
+
+    intrinsic_causal_influence(causal_model, 'X1', attribution_func=my_attr_func)

--- a/tests/gcm/test_intrinsic_influence.py
+++ b/tests/gcm/test_intrinsic_influence.py
@@ -64,7 +64,7 @@ def test_intrinsic_causal_influence_categorical():
         -estimate_entropy_of_probabilities(log_mdl.predict_proba(np.column_stack([X0, N1, N2, N3])))
     expected_output_empty_subset = -estimate_entropy_of_probabilities(np.array([[0.5, 0.5]]))
 
-    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_evaluation_samples=100)
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_samples_of_interest=100)
     assert iccs['X0'] == approx(0.14, abs=0.05)
     assert iccs['X1'] == approx(0.01, abs=0.05)
     assert iccs['X2'] == approx(0.38, abs=0.05)
@@ -73,7 +73,7 @@ def test_intrinsic_causal_influence_categorical():
     assert np.sum([iccs[key] for key in iccs]) == approx(expected_output_full_subset - expected_output_empty_subset,
                                                          abs=0.05)
 
-    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_evaluation_samples=100)
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_samples_of_interest=100)
     assert iccs['X0'] == approx(0.14, abs=0.05)
     assert iccs['X1'] == approx(0.01, abs=0.05)
     assert iccs['X2'] == approx(0.38, abs=0.05)
@@ -119,7 +119,7 @@ def test_intrinsic_causal_influence_categorical_2():
     expected_output_full_subset = -estimate_entropy_of_probabilities(log_mdl.predict_proba(X))
     expected_output_empty_subset = -estimate_entropy_of_probabilities(np.array([[0.5, 0.5]]))
 
-    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_evaluation_samples=100)
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_samples_of_interest=100)
     assert iccs['X0'] == approx(0.05, abs=0.05)
     assert iccs['X1'] == approx(0.03, abs=0.05)
     assert iccs['X2'] == approx(0.1, abs=0.05)
@@ -128,7 +128,7 @@ def test_intrinsic_causal_influence_categorical_2():
     assert np.sum([iccs[key] for key in iccs]) == approx(expected_output_full_subset - expected_output_empty_subset,
                                                          abs=0.05)
 
-    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_evaluation_samples=100)
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_samples_of_interest=100)
     assert iccs['X0'] == approx(0.05, abs=0.05)
     assert iccs['X1'] == approx(0.03, abs=0.05)
     assert iccs['X2'] == approx(0.1, abs=0.05)
@@ -161,7 +161,7 @@ def test_given_only_categorical_data_when_estimate_icc_then_does_not_fail():
     expected_output_full_subset = -estimate_entropy_of_probabilities(log_mdl.predict_probabilities(X))
     expected_output_empty_subset = -estimate_entropy_of_probabilities(np.array([[0.5, 0.5]]))
 
-    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_evaluation_samples=100)
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='approx', num_samples_of_interest=100)
     assert iccs['X0'] == approx(0.08, abs=0.03)
     assert iccs['X1'] == approx(0, abs=0.005)
     assert iccs['X2'] == approx(0.33, abs=0.05)
@@ -170,7 +170,7 @@ def test_given_only_categorical_data_when_estimate_icc_then_does_not_fail():
     assert np.sum([iccs[key] for key in iccs]) == approx(expected_output_full_subset - expected_output_empty_subset,
                                                          abs=0.05)
 
-    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_evaluation_samples=100)
+    iccs = intrinsic_causal_influence(causal_model, 'X3', prediction_model='exact', num_samples_of_interest=100)
     assert iccs['X0'] == approx(0.08, abs=0.03)
     assert iccs['X1'] == approx(0, abs=0.005)
     assert iccs['X2'] == approx(0.33, abs=0.05)


### PR DESCRIPTION
This PR introduces the influence module which provides functionality for computing direct arrow strength in causal graphs and intrinsic causal influence.

It requires:
- https://github.com/py-why/dowhy/pull/452

to be merged first.