### PR TITLE
Add the API for estimating average causal effect using GCM

### DIFF
--- a/dowhy/gcm/__init__.py
+++ b/dowhy/gcm/__init__.py
@@ -11,7 +11,7 @@ from .fitting_sampling import fit, draw_samples
 from .graph import StochasticModel, ConditionalStochasticModel, FunctionalCausalModel, DirectedGraph, is_root_node
 from .influence import arrow_strength, intrinsic_causal_influence
 from .stochastic_models import EmpiricalDistribution, BayesianGaussianMixtureDistribution, ScipyDistribution
-from .whatif import interventional_samples, counterfactual_samples
+from .whatif import interventional_samples, counterfactual_samples, average_causal_effect
 from .distribution_change import distribution_change, distribution_change_of_graphs
 from .independence_test import independence_test, kernel_based, approx_kernel_based, regression_based
 from . import util, ml, auto

--- a/dowhy/gcm/whatif.py
+++ b/dowhy/gcm/whatif.py
@@ -11,9 +11,10 @@ import pandas as pd
 
 from dowhy.gcm._noise import compute_noise_from_data
 from dowhy.gcm.cms import ProbabilisticCausalModel, InvertibleStructuralCausalModel, StructuralCausalModel
+from dowhy.gcm.fcms import ClassifierFCM
 from dowhy.gcm.fitting_sampling import draw_samples
-from dowhy.gcm.graph import is_root_node, DirectedGraph, validate_causal_dag, \
-    validate_node_in_graph, get_ordered_predecessors
+from dowhy.gcm.graph import get_ordered_predecessors, is_root_node, DirectedGraph, validate_causal_dag, \
+    validate_node_in_graph, node_connected_subgraph_view
 
 
 def interventional_samples(causal_model: ProbabilisticCausalModel,
@@ -166,6 +167,80 @@ def _evaluate_intervention(node: Any,
         return post_intervention_data
     else:
         return pre_intervention_data
+
+
+def average_causal_effect(causal_model: ProbabilisticCausalModel,
+                          target_node: Any,
+                          interventions_alternative: Dict[Any, Callable[[np.ndarray], Union[float, np.ndarray]]],
+                          interventions_reference: Dict[Any, Callable[[np.ndarray], Union[float, np.ndarray]]],
+                          observed_data: Optional[pd.DataFrame] = None,
+                          num_samples_to_draw: Optional[int] = None) -> float:
+    """ Estimates the average causal effect (ACE) on the target of two different sets of interventions.
+    The interventions can be specified through the parameters `interventions_alternative` and `interventions_reference`.
+    For example, if the alternative intervention is do(T := 1) and the reference intervention
+    is do(T := 0), then the average causal effect is given by ACE = E[Y | do(T := 1)] - E[Y | do(T := 0)]:
+        >>> average_causal_effect(causal_model, 'Y', {'T': lambda _ : 1}, {'T': lambda _ : 0})
+
+    We can also specify more complex interventions on multiple nodes:
+        >>> average_causal_effect(causal_model,
+        >>>                       'Y',
+        >>>                       {'T': lambda _ : 1, 'X0': lambda x : x + 1},
+        >>>                       {'T': lambda _ : 0, 'X0': lambda x : x * 2})
+    In the above, we would estimate ACE = E[Y | do(T := 1), do(X0 := X0 + 1)] - E[Y | do(T := 0), do(X0 := X0 * 2)].
+
+    Note: The target node can be a continuous real-valued variable or a categorical variable with at most two classes
+    (i.e. binary).
+
+    :param causal_model: The probabilistic causal model we perform this intervention on .
+    :param target_node: Target node for which the ACE is estimated.
+    :param interventions_alternative: Dictionary defining the interventions for the alternative values.
+    :param interventions_reference: Dictionary defining the interventions for the reference values.
+    :param observed_data: Factual data that we observe for the nodes in the causal graph. By default, new data
+                          is sampled using the causal model. If observational data is available, providing them
+                          might improve the accuracy by mitigating issues due to a misspecified graph and/or causal
+                          models.
+    :param num_samples_to_draw: Number of samples drawn from the causal model for estimating ACE if no observed data is
+                                given.
+    :return: The estimated average causal effect (ACE).
+    """
+    # For estimating the effect, we only need to consider the nodes that have a directed path to the target node, i.e.
+    # all ancestors of the target.
+    causal_model = ProbabilisticCausalModel(node_connected_subgraph_view(causal_model.graph, target_node))
+
+    validate_causal_dag(causal_model.graph)
+    for node in interventions_alternative:
+        validate_node_in_graph(causal_model.graph, node)
+    for node in interventions_reference:
+        validate_node_in_graph(causal_model.graph, node)
+
+    if observed_data is None and num_samples_to_draw is None:
+        raise ValueError("Either observed_samples or num_samples_to_draw need to be set!")
+    if observed_data is not None and num_samples_to_draw is not None:
+        raise ValueError("Either observed_samples or num_samples_to_draw need to be set, not both!")
+
+    if num_samples_to_draw is not None:
+        observed_data = draw_samples(causal_model, num_samples_to_draw)
+
+    samples_from_target_alt = _interventional_samples(causal_model, observed_data, interventions_alternative)[
+        target_node].to_numpy()
+    samples_from_target_ref = _interventional_samples(causal_model, observed_data, interventions_reference)[
+        target_node].to_numpy()
+
+    target_causal_model = causal_model.causal_mechanism(target_node)
+    if isinstance(target_causal_model, ClassifierFCM):
+        # The target node can be a continuous real-valued variable or a categorical variable with at most two classes
+        # (i.e. binary).
+        if observed_data[target_node].nunique() > 2:
+            raise ValueError(
+                "Cannot estimate average treatment effect of categorical data with more than 2 categories!")
+
+        class_names = target_causal_model.get_class_names(np.array([0, 1]))
+        samples_from_target_alt[samples_from_target_alt == class_names[0]] = 0
+        samples_from_target_alt[samples_from_target_alt == class_names[1]] = 1
+        samples_from_target_ref[samples_from_target_ref == class_names[0]] = 0
+        samples_from_target_ref[samples_from_target_ref == class_names[1]] = 1
+
+    return np.mean(samples_from_target_alt) - np.mean(samples_from_target_ref)
 
 
 def _parent_samples_of(node: Any, scm: ProbabilisticCausalModel, samples: pd.DataFrame) -> np.ndarray:

--- a/tests/gcm/test_whatif.py
+++ b/tests/gcm/test_whatif.py
@@ -6,7 +6,7 @@ from flaky import flaky
 from pytest import approx
 
 from dowhy.gcm import ClassifierFCM, AdditiveNoiseModel, EmpiricalDistribution, fit, interventional_samples, \
-    ProbabilisticCausalModel, counterfactual_samples, InvertibleStructuralCausalModel
+    ProbabilisticCausalModel, counterfactual_samples, InvertibleStructuralCausalModel, average_causal_effect, auto
 from dowhy.gcm.ml import create_linear_regressor, create_logistic_regression_classifier
 
 
@@ -144,7 +144,8 @@ def test_interventional_samples_raise_error_both_parameter_given():
     observed_data = pd.DataFrame({'X0': [0], 'X1': [1], 'X2': [2], 'X3': [3]})
 
     with pytest.raises(ValueError):
-        interventional_samples(causal_model, dict(X0=lambda x: 10), observed_data=observed_data, num_samples_to_draw=100)
+        interventional_samples(causal_model, dict(X0=lambda x: 10), observed_data=observed_data,
+                               num_samples_to_draw=100)
 
 
 def test_counterfactual_samples_with_observed_samples():
@@ -192,3 +193,43 @@ def test_counterfactual_samples_raises_error_both_parameter_given():
                                dict(X0=lambda x: 10),
                                observed_data=pd.DataFrame({'X0': [1], 'X1': [3], 'X2': [3], 'X3': [4]}),
                                noise_data=pd.DataFrame({'X0': [1], 'X1': [4], 'X2': [3], 'X3': [4]}))
+
+
+@flaky(max_runs=3)
+def test_given_continuous_target_when_estimate_average_causal_effect_then_return_expected_result():
+    T = np.random.choice(2, 1000, replace=True)
+    X0 = np.random.normal(0, 0.2, 1000) + T
+    X1 = np.random.normal(0, 0.2, 1000) + 0.5 * T
+    Y = X0 + X1 + np.random.normal(0, 0.1, 1000)
+
+    data = pd.DataFrame(dict(T=T, X0=X0, X1=X1, Y=Y))
+
+    causal_model = ProbabilisticCausalModel(nx.DiGraph([('T', 'X0'), ('T', 'X1'), ('X0', 'Y'), ('X1', 'Y')]))
+    auto.assign_causal_mechanisms(causal_model, data, auto.AssignmentQuality.GOOD)
+    fit(causal_model, data)
+
+    assert average_causal_effect(causal_model,
+                                 'Y',
+                                 interventions_alternative={'T': lambda x: 1},
+                                 interventions_reference={'T': lambda x: 0},
+                                 num_samples_to_draw=1000) == approx(1.5, abs=0.1)
+
+
+@flaky(max_runs=3)
+def test_given_binary_target_when_estimate_average_causal_effect_then_return_expected_result():
+    T = np.random.choice(2, 1000, replace=True)
+    X0 = np.random.normal(0, 0.1, 1000) + T
+    X1 = np.random.normal(0, 0.1, 1000) + 0.5 * T
+    Y = ((X0 + X1 + np.random.normal(0, 0.1, 1000)) >= 1.5).astype(str)
+
+    data = pd.DataFrame(dict(T=T, X0=X0, X1=X1, Y=Y))
+
+    causal_model = ProbabilisticCausalModel(nx.DiGraph([('T', 'X0'), ('T', 'X1'), ('X0', 'Y'), ('X1', 'Y')]))
+    auto.assign_causal_mechanisms(causal_model, data, auto.AssignmentQuality.GOOD)
+    fit(causal_model, data)
+
+    assert average_causal_effect(causal_model,
+                                 'Y',
+                                 interventions_alternative={'T': lambda x: 1},
+                                 interventions_reference={'T': lambda x: 0},
+                                 num_samples_to_draw=1000) == approx(0.5, abs=0.1)


### PR DESCRIPTION
This PR introduces an API for estimating average causal effect on the target of two sets of interventions.