### PR TITLE
Add auto module to the main namespace

### DIFF
--- a/dowhy/gcm/__init__.py
+++ b/dowhy/gcm/__init__.py
@@ -11,4 +11,4 @@ from .stochastic_models import EmpiricalDistribution, BayesianGaussianMixtureDis
 from .whatif import interventional_samples, counterfactual_samples
 from .distribution_change import distribution_change, distribution_change_of_graphs
 from .independence_test import kernel_based, approx_kernel_based
-from . import util, ml
+from . import util, ml, auto

--- a/tests/gcm/test_auto.py
+++ b/tests/gcm/test_auto.py
@@ -144,3 +144,8 @@ def test_given_non_linear_classification_problem_when_auto_assign_causal_models_
     assign_causal_mechanisms(causal_model, pd.DataFrame(data), quality=AssignmentQuality.BETTER)
     assert not isinstance(causal_model.causal_mechanism('Y').classifier_model.sklearn_model, LogisticRegression)
     assert not isinstance(causal_model.causal_mechanism('Y').classifier_model.sklearn_model, GaussianNB)
+
+
+def test_when_auto_called_from_main_namespace_returns_no_attribute_error():
+    from dowhy import gcm
+    _ = gcm.auto.AssignmentQuality.GOOD


### PR DESCRIPTION
This PR adds the `auto` module to the `gcm` namespace, so that public artefacts of `auto` module can be invoked with `gcm.auto` prefix.

    from dowhy import gcm
    quality = gcm.auto.AssignmentQuality.GOOD