### PR TITLE
Make sure placebo treatments are assigned consistently for categorical treatments

### DIFF
--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -123,7 +123,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
                     self.logger.info("Using a Discrete Uniform Distribution with the following categories:{}"
                     .format(categories))
                     sample = np.random.choice(categories, size=num_rows)
-                    new_treatment = pd.Series(sample).astype('category')
+                    new_treatment = pd.Series(sample, index=self._data.index).astype('category')
 
             # Create a new column in the data by the name of placebo
             new_data = self._data.assign(placebo=new_treatment)

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -24,14 +24,16 @@ class TestRefuter(object):
 
     def null_refutation_test(self, data=None, dataset="linear", beta=10,
             num_common_causes=1, num_instruments=1, num_samples=100000,
-            treatment_is_binary=True, num_dummyoutcome_simulations=None):
+            treatment_is_binary=True, treatment_is_category=False,
+            num_dummyoutcome_simulations=None):
         # Supports user-provided dataset object
         if data is None:
             data = dowhy.datasets.linear_dataset(beta=beta,
                                              num_common_causes=num_common_causes,
                                              num_instruments=num_instruments,
                                              num_samples=num_samples,
-                                             treatment_is_binary=treatment_is_binary)
+                                             treatment_is_binary=treatment_is_binary,
+                                             treatment_is_category=treatment_is_category)
 
         print(data['df'])
 
@@ -209,6 +211,18 @@ class TestRefuter(object):
             self.null_refutation_test(num_common_causes=0, num_samples=num_samples,
                     treatment_is_binary=False,
                     num_dummyoutcome_simulations=num_dummyoutcome_simulations)
+
+    def categorical_treatment_testsuite(self, num_samples=100000,
+                                       num_common_causes=1,tests_to_run="all",
+                                       num_dummyoutcome_simulations=2):
+        self.null_refutation_test(
+            num_common_causes=num_common_causes,num_samples=num_samples,
+            treatment_is_binary=False, treatment_is_category=True,
+            num_dummyoutcome_simulations=num_dummyoutcome_simulations)
+        if tests_to_run != "atleast-one-common-cause":
+            self.null_refutation_test(num_common_causes=0, num_samples=num_samples,
+                                      treatment_is_binary=False, treatment_is_category=True,
+                                      num_dummyoutcome_simulations=num_dummyoutcome_simulations)
 
 
 

--- a/tests/causal_refuters/test_placebo_refuter.py
+++ b/tests/causal_refuters/test_placebo_refuter.py
@@ -1,6 +1,9 @@
 import pytest
-import numpy as np
+import random
+import pandas as pd
 from .base import TestRefuter
+import dowhy.datasets
+
 
 @pytest.mark.usefixtures("fixed_seed")
 class TestPlaceboRefuter(object):
@@ -24,3 +27,18 @@ class TestPlaceboRefuter(object):
                                                estimator_method, num_samples):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
         refuter_tester.categorical_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_samples"],
+                             [(0.1, "backdoor.linear_regression", 5000)])
+    def test_refutation_placebo_refuter_category_non_consecutive_index(self, error_tolerance,
+                                                 estimator_method, num_samples):
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
+        data = dowhy.datasets.linear_dataset(beta=10,
+                                             num_common_causes=1,
+                                             num_instruments=1,
+                                             num_samples=num_samples,
+                                             treatment_is_binary=False,
+                                             treatment_is_category=True)
+        random_index = random.sample(range(1, 10*num_samples), num_samples)
+        data['df'].index = random_index
+        refuter_tester.null_refutation_test(data=data)

--- a/tests/causal_refuters/test_placebo_refuter.py
+++ b/tests/causal_refuters/test_placebo_refuter.py
@@ -17,3 +17,10 @@ class TestPlaceboRefuter(object):
             estimator_method, num_samples):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
         refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_samples"],
+                             [(0.1, "backdoor.linear_regression", 5000)])
+    def test_refutation_placebo_refuter_category(self, error_tolerance,
+                                               estimator_method, num_samples):
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
+        refuter_tester.categorical_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)


### PR DESCRIPTION
Give the placebo column the same index as the original data in case of categorical treatments to avoid later mismatches. Fixes #316.

As there were no tests yet for categorical treatment refutation, I decided to not add a full suite like in the case of binary/continuous treatment without more feedback. Am happy to add that, or a single dedicated test if desired.