### PR TITLE
Calculate propensity score from function without refitting, if possible

### DIFF
--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 from sklearn import linear_model
+from sklearn.exceptions import NotFittedError
 
 from dowhy.causal_estimator import CausalEstimator
 
@@ -82,8 +83,12 @@ class PropensityScoreEstimator(CausalEstimator):
                     raise ValueError(f"""Propensity score column {self.propensity_score_column} does not exist, nor does a propensity_model. 
                     Please specify the column name that has your pre-computed propensity score, or a model to compute it.""")
                 else:
-                    self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(
-                        self._observed_common_causes)[:, 1]
+                    try:
+                        self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(
+                            self._observed_common_causes)[:, 1]
+                    except NotFittedError:
+                        raise NotFittedError("Please fit the propensity score model before calling predict_proba")
+
             else:
                 self.logger.info(f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
 

--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from sklearn import linear_model
 
 from dowhy.causal_estimator import CausalEstimator
 
@@ -67,6 +68,24 @@ class PropensityScoreEstimator(CausalEstimator):
             error_msg = "No common causes/confounders present. Propensity score based methods are not applicable"
             self.logger.error(error_msg)
             raise Exception(error_msg)
+
+    def _refresh_propensity_score(self):
+        if self.recalculate_propensity_score is True:
+            if self.propensity_score_model is None:
+                self.propensity_score_model = linear_model.LogisticRegression()
+            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
+            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
+        else:
+            # check if user provides the propensity score column
+            if self.propensity_score_column not in self._data.columns:
+                if self.propensity_score_model is None:
+                    raise ValueError(f"""Propensity score column {self.propensity_score_column} does not exist, nor does a propensity_model. 
+                    Please specify the column name that has your pre-computed propensity score, or a model to compute it.""")
+                else:
+                    self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(
+                        self._observed_common_causes)[:, 1]
+            else:
+                self.logger.info(f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
 
     def construct_symbolic_estimator(self, estimand):
         '''

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -47,18 +47,7 @@ class PropensityScoreMatchingEstimator(PropensityScoreEstimator):
         self.logger.info(self.symbolic_estimator)
 
     def _estimate_effect(self):
-        if self.recalculate_propensity_score is True:
-            if self.propensity_score_model is None:
-                self.propensity_score_model = linear_model.LogisticRegression()
-            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
-            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
-        else:
-            # check if the user provides a propensity score column
-            if self.propensity_score_column not in self._data.columns:
-                raise ValueError(f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
-            else:
-                self.logger.info(f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
-
+        self._refresh_propensity_score()
 
         # this assumes a binary treatment regime
         treated = self._data.loc[self._data[self._treatment_name[0]] == 1]

--- a/dowhy/causal_estimators/propensity_score_stratification_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_stratification_estimator.py
@@ -66,17 +66,8 @@ class PropensityScoreStratificationEstimator(PropensityScoreEstimator):
 
 
     def _estimate_effect(self):
-        if self.recalculate_propensity_score is True:
-            if self.propensity_score_model is None:
-                self.propensity_score_model = linear_model.LogisticRegression()
-            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
-            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
-        else:
-            # check if the user provides the propensity score column
-            if self.propensity_score_column not in self._data.columns:
-                raise ValueError(f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
-            else:
-                self.logger.info(f"Using pre-computed propensity score incolumn {self.propensity_score_column}")
+        self._refresh_propensity_score()
+
         clipped = None
         # Infer the right strata based on clipping threshold
         if self.num_strata == "auto":

--- a/dowhy/causal_estimators/propensity_score_weighting_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_weighting_estimator.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from sklearn import linear_model
+
 
 from dowhy.causal_estimator import CausalEstimate
 from dowhy.causal_estimators.propensity_score_estimator import PropensityScoreEstimator
@@ -72,17 +72,7 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         self.max_ps_score = max_ps_score
 
     def _estimate_effect(self):
-        if self.recalculate_propensity_score is True:
-            if self.propensity_score_model is None:
-                self.propensity_score_model = linear_model.LogisticRegression()
-            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
-            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
-        else:
-            # check if user provides the propensity score column
-            if self.propensity_score_column not in self._data.columns:
-                raise ValueError(f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
-            else:
-                self.logger.info(f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
+        self._refresh_propensity_score()
 
         # trim propensity score weights
         self._data[self.propensity_score_column] = np.minimum(self.max_ps_score, self._data[self.propensity_score_column])


### PR DESCRIPTION
For propensity score estimators, if `recalculate_propensity_score=False` and the `propensity_score_column` is missing, but the `propensity_score_function` exists, instead of failing, use the function to fill in the score, but without refitting the function.

Factor this logic out to the parent class `PropensityScoreEstimator`