### PR TITLE
Two sided bootstrap test

### DIFF
--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -175,7 +175,7 @@ class CausalRefuter:
         # Sort the simulations
         simulations.sort()
         # Obtain the median value
-        median_refute_values= simulations[int(num_simulations/2)]
+        median_refute_values = simulations[int(num_simulations/2)]
 
         # Performing a two sided test
         if estimate.value > median_refute_values:

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -189,8 +189,8 @@ class CausalRefuter:
             estimate_index = np.searchsorted(simulations, estimate.value, side="right")
             # We get the probability with respect to the left tail.
             p_value = estimate_index / num_simulations
-
-        return p_value
+        # return twice the determined quantile as this is a two sided test
+        return 2*p_value
 
     def perform_normal_distribution_test(self, estimate, simulations):
         # Get the mean for the simulations

--- a/tests/test_causal_refuter.py
+++ b/tests/test_causal_refuter.py
@@ -1,7 +1,10 @@
 import pytest
+from flaky import flaky
+import numpy as np
 
 from dowhy.causal_refuter import CausalRefuter
 from dowhy.causal_identifier import IdentifiedEstimand
+from dowhy.causal_estimator import CausalEstimate
 
 
 class MockRefuter(CausalRefuter):
@@ -12,3 +15,12 @@ def test_causal_refuter_placeholder_method():
 	refuter = MockRefuter(None, IdentifiedEstimand(None, None, None), None)
 	with pytest.raises(NotImplementedError):
 		refuter.refute_estimate()
+
+
+@flaky(max_runs=3)
+def test_causal_refuter_bootstrap_test():
+	estimator = CausalEstimate(0, None, None, None, None)
+	refuter = MockRefuter(None, IdentifiedEstimand(None, None, None), None)
+	simulations = np.random.normal(0, 1, 5000)
+	pvalue = refuter.perform_bootstrap_test(estimator, simulations)
+	assert pvalue > .95


### PR DESCRIPTION
Makes sure the bootstrap test for refutation returns p-value corresponding to a two-sided not a one-sided test. Fixes #375 