### PR TITLE
Speed up refutation by parallelization

### DIFF
--- a/docs/source/example_notebooks/dowhy_simple_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_simple_example.ipynb
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model.view_model()"
+    "model.view_model()"
    ]
   },
   {
@@ -133,8 +133,8 @@
    },
    "outputs": [],
    "source": [
-    "# from IPython.display import Image, display\n",
-    "# display(Image(filename=\"causal_model.png\"))"
+    "from IPython.display import Image, display\n",
+    "display(Image(filename=\"causal_model.png\"))"
    ]
   },
   {
@@ -246,7 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model.view_model()"
+    "model.view_model()"
    ]
   },
   {
@@ -255,8 +255,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from IPython.display import Image, display\n",
-    "# display(Image(filename=\"causal_model.png\"))"
+    "from IPython.display import Image, display\n",
+    "display(Image(filename=\"causal_model.png\"))"
    ]
   },
   {
@@ -330,22 +330,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "\n",
     "res_random=model.refute_estimate(identified_estimand, estimate, method_name=\"random_common_cause\")\n",
-    "print(res_random)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "res_random=model.refute_estimate(identified_estimand, estimate, \n",
-    "    method_name=\"random_common_cause\", n_jobs=-1, verbose=10)\n",
     "print(res_random)"
    ]
   },
@@ -362,23 +347,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "\n",
     "res_placebo=model.refute_estimate(identified_estimand, estimate,\n",
     "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\")\n",
-    "print(res_placebo)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "res_placebo=model.refute_estimate(identified_estimand, estimate,\n",
-    "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\", n_jobs=-1, verbose=10)\n",
     "print(res_placebo)"
    ]
   },
@@ -405,7 +375,10 @@
    "metadata": {},
    "source": [
     "As you can see, the propensity score stratification estimator is reasonably robust to refutations.\n",
-    "For reproducibility, you can add a parameter \"random_seed\" to any refutation method, as shown below."
+    "\n",
+    "**Reproducability and Parallelization**: For reproducibility, you can add a parameter \"random_seed\" to any refutation method, as shown below.\n",
+    "\n",
+    "You can also use built-in parallelization to speed up the refutation process. Simply set `n_jobs` to a value greater than 1 to spread the workload to multiple CPUs, or set `n_jobs=-1` to use all CPUs. "
    ]
   },
   {
@@ -415,7 +388,7 @@
    "outputs": [],
    "source": [
     "res_subset=model.refute_estimate(identified_estimand, estimate,\n",
-    "        method_name=\"data_subset_refuter\", subset_fraction=0.9, random_seed = 1)\n",
+    "        method_name=\"data_subset_refuter\", subset_fraction=0.9, random_seed = 1, n_jobs=-1, verbose=10)\n",
     "print(res_subset)"
    ]
   },
@@ -637,11 +610,6 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "b3273f06edc005084d721bf5395ac67cca29d6f43d52ff2cb1fc0df4a110b9d3"
-   }
   }
  },
  "nbformat": 4,

--- a/docs/source/example_notebooks/dowhy_simple_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_simple_example.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,35 +57,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "         X0   Z0        Z1        W0        W1        W2        W3 W4     v0  \\\n",
-      "0 -1.028297  0.0  0.646030 -1.878060  0.150553  1.491506  1.734036  0  False   \n",
-      "1  0.838949  0.0  0.541206 -0.111856  0.605361 -1.369900  0.131285  0   True   \n",
-      "2  0.331331  1.0  0.084589 -0.051030 -0.091119  0.246438 -0.489620  0   True   \n",
-      "3 -0.339749  1.0  0.789053 -0.055833 -0.198793 -0.459297 -1.287210  2   True   \n",
-      "4  2.034091  0.0  0.860169 -0.239737  0.255664  0.644762 -1.182604  3   True   \n",
-      "\n",
-      "           y  \n",
-      "0   4.168584  \n",
-      "1   8.602900  \n",
-      "2  10.597395  \n",
-      "3  14.240394  \n",
-      "4  31.807916  \n",
-      "digraph {v0->y;W0-> v0; W1-> v0; W2-> v0; W3-> v0; W4-> v0;Z0-> v0; Z1-> v0;W0-> y; W1-> y; W2-> y; W3-> y; W4-> y;X0-> y;}\n",
-      "\n",
-      "\n",
-      "graph[directed 1node[ id \"y\" label \"y\"]node[ id \"W0\" label \"W0\"] node[ id \"W1\" label \"W1\"] node[ id \"W2\" label \"W2\"] node[ id \"W3\" label \"W3\"] node[ id \"W4\" label \"W4\"]node[ id \"Z0\" label \"Z0\"] node[ id \"Z1\" label \"Z1\"]node[ id \"v0\" label \"v0\"]edge[source \"v0\" target \"y\"]edge[ source \"W0\" target \"v0\"] edge[ source \"W1\" target \"v0\"] edge[ source \"W2\" target \"v0\"] edge[ source \"W3\" target \"v0\"] edge[ source \"W4\" target \"v0\"]edge[ source \"Z0\" target \"v0\"] edge[ source \"Z1\" target \"v0\"]edge[ source \"W0\" target \"y\"] edge[ source \"W1\" target \"y\"] edge[ source \"W2\" target \"y\"] edge[ source \"W3\" target \"y\"] edge[ source \"W4\" target \"y\"]node[ id \"X0\" label \"X0\"] edge[ source \"X0\" target \"y\"]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = dowhy.datasets.linear_dataset(beta=10,\n",
     "        num_common_causes=5,\n",
@@ -127,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -183,40 +159,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Estimand type: nonparametric-ate\n",
-      "\n",
-      "### Estimand : 1\n",
-      "Estimand name: backdoor\n",
-      "Estimand expression:\n",
-      "  d                       \n",
-      "─────(E[y|W3,W2,W0,W4,W1])\n",
-      "d[v₀]                     \n",
-      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
-      "\n",
-      "### Estimand : 2\n",
-      "Estimand name: iv\n",
-      "Estimand expression:\n",
-      " ⎡                              -1⎤\n",
-      " ⎢    d        ⎛    d          ⎞  ⎥\n",
-      "E⎢─────────(y)⋅⎜─────────([v₀])⎟  ⎥\n",
-      " ⎣d[Z₁  Z₀]    ⎝d[Z₁  Z₀]      ⎠  ⎦\n",
-      "Estimand assumption 1, As-if-random: If U→→y then ¬(U →→{Z1,Z0})\n",
-      "Estimand assumption 2, Exclusion: If we remove {Z1,Z0}→{v0}, then ¬({Z1,Z0}→y)\n",
-      "\n",
-      "### Estimand : 3\n",
-      "Estimand name: frontdoor\n",
-      "No such variable(s) found!\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "identified_estimand = model.identify_effect(proceed_when_unidentifiable=True)\n",
     "print(identified_estimand)"
@@ -238,40 +183,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "propensity_score_stratification\n",
-      "*** Causal Estimate ***\n",
-      "\n",
-      "## Identified estimand\n",
-      "Estimand type: nonparametric-ate\n",
-      "\n",
-      "### Estimand : 1\n",
-      "Estimand name: backdoor\n",
-      "Estimand expression:\n",
-      "  d                       \n",
-      "─────(E[y|W3,W2,W0,W4,W1])\n",
-      "d[v₀]                     \n",
-      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
-      "\n",
-      "## Realized estimand\n",
-      "b: y~v0+W3+W2+W0+W4+W1\n",
-      "Target units: ate\n",
-      "\n",
-      "## Estimate\n",
-      "Mean value: 10.813313102608985\n",
-      "\n",
-      "Causal Estimate is 10.813313102608985\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "causal_estimate = model.estimate_effect(identified_estimand,\n",
     "        method_name=\"backdoor.propensity_score_stratification\")\n",
@@ -288,38 +204,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "propensity_score_stratification\n",
-      "*** Causal Estimate ***\n",
-      "\n",
-      "## Identified estimand\n",
-      "Estimand type: nonparametric-ate\n",
-      "\n",
-      "### Estimand : 1\n",
-      "Estimand name: backdoor\n",
-      "Estimand expression:\n",
-      "  d                       \n",
-      "─────(E[y|W3,W2,W0,W4,W1])\n",
-      "d[v₀]                     \n",
-      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
-      "\n",
-      "## Realized estimand\n",
-      "b: y~v0+W3+W2+W0+W4+W1\n",
-      "Target units: atc\n",
-      "\n",
-      "## Estimate\n",
-      "Mean value: 10.726459088224193\n",
-      "\n",
-      "Causal Estimate is 10.726459088224193\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Causal effect on the control group (ATC)\n",
     "causal_estimate_att = model.estimate_effect(identified_estimand,\n",
@@ -338,19 +225,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:dowhy.causal_model:Causal Graph not provided. DoWhy will construct a graph based on data inputs.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Without graph                                       \n",
     "model= CausalModel(                             \n",
@@ -363,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,38 +286,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "propensity_score_stratification\n",
-      "*** Causal Estimate ***\n",
-      "\n",
-      "## Identified estimand\n",
-      "Estimand type: nonparametric-ate\n",
-      "\n",
-      "### Estimand : 1\n",
-      "Estimand name: backdoor\n",
-      "Estimand expression:\n",
-      "  d                       \n",
-      "─────(E[y|W3,W2,W0,W4,W1])\n",
-      "d[v₀]                     \n",
-      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
-      "\n",
-      "## Realized estimand\n",
-      "b: y~v0+W3+W2+W0+W4+W1\n",
-      "Target units: ate\n",
-      "\n",
-      "## Estimate\n",
-      "Mean value: 10.813313102608985\n",
-      "\n",
-      "Causal Estimate is 10.813313102608985\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "estimate = model.estimate_effect(identified_estimand,\n",
     "                                 method_name=\"backdoor.propensity_score_stratification\")         \n",
@@ -476,22 +326,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Refute: Add a random common cause\n",
-      "Estimated effect:10.813313102608985\n",
-      "New effect:10.733524844585846\n",
-      "p value:0.28\n",
-      "\n",
-      "Wall time: 56.4 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
@@ -501,42 +338,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 8 concurrent workers.\n",
-      "[Parallel(n_jobs=-1)]: Done  34 tasks      | elapsed:   15.8s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Refute: Add a random common cause\n",
-      "Estimated effect:10.813313102608985\n",
-      "New effect:10.73736604023241\n",
-      "p value:0.41999999999999993\n",
-      "\n",
-      "Wall time: 28 s\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=-1)]: Done 100 out of 100 | elapsed:   27.9s finished\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
     "res_random=model.refute_estimate(identified_estimand, estimate, \n",
-    "    method_name=\"random_common_cause\", n_jobs=-1, verbose=1)\n",
+    "    method_name=\"random_common_cause\", n_jobs=-1, verbose=10)\n",
     "print(res_random)"
    ]
   },
@@ -549,22 +358,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Refute: Use a Placebo Treatment\n",
-      "Estimated effect:10.813313102608985\n",
-      "New effect:0.022048036076712393\n",
-      "p value:0.84\n",
-      "\n",
-      "Wall time: 1min 4s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
@@ -575,42 +371,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 8 concurrent workers.\n",
-      "[Parallel(n_jobs=-1)]: Done  34 tasks      | elapsed:   10.6s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Refute: Use a Placebo Treatment\n",
-      "Estimated effect:10.813313102608985\n",
-      "New effect:0.00424689283417187\n",
-      "p value:0.94\n",
-      "\n",
-      "Wall time: 22.7 s\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[Parallel(n_jobs=-1)]: Done 100 out of 100 | elapsed:   22.6s finished\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
     "res_placebo=model.refute_estimate(identified_estimand, estimate,\n",
-    "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\", n_jobs=-1, verbose=1)\n",
+    "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\", n_jobs=-1, verbose=10)\n",
     "print(res_placebo)"
    ]
   },
@@ -777,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -803,42 +571,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Refute: Add a random common cause\n",
-      "Estimated effect:10.813313102608985\n",
-      "New effect:10.746344435527632\n",
-      "p value:0.48\n",
-      "\n",
-      "Refute: Use a Placebo Treatment\n",
-      "Estimated effect:10.813313102608985\n",
-      "New effect:0.030281612224610566\n",
-      "p value:0.94\n",
-      "\n",
-      "Refute: Use a subset of data\n",
-      "Estimated effect:10.813313102608985\n",
-      "New effect:10.758932868564031\n",
-      "p value:0.52\n",
-      "\n",
-      "Wall time: 1min 27s\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[None, None, None]"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
@@ -846,7 +581,7 @@
     "refute = partial(model.refute_estimate, identified_estimand, estimate)\n",
     "\n",
     "# run refutation methods in parallel\n",
-    "results = Parallel(n_jobs=4)(delayed(refute)(**kwds) for kwds in kwargs_list)\n",
+    "results = Parallel(n_jobs=4, verbose=10)(delayed(refute)(**kwds) for kwds in kwargs_list)\n",
     "\n",
     "# print results\n",
     "[print(res) for res in results]"
@@ -854,17 +589,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Wall time: 3min 9s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",

--- a/docs/source/example_notebooks/dowhy_simple_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_simple_example.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,11 +57,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         X0   Z0        Z1        W0        W1        W2        W3 W4     v0  \\\n",
+      "0 -1.028297  0.0  0.646030 -1.878060  0.150553  1.491506  1.734036  0  False   \n",
+      "1  0.838949  0.0  0.541206 -0.111856  0.605361 -1.369900  0.131285  0   True   \n",
+      "2  0.331331  1.0  0.084589 -0.051030 -0.091119  0.246438 -0.489620  0   True   \n",
+      "3 -0.339749  1.0  0.789053 -0.055833 -0.198793 -0.459297 -1.287210  2   True   \n",
+      "4  2.034091  0.0  0.860169 -0.239737  0.255664  0.644762 -1.182604  3   True   \n",
+      "\n",
+      "           y  \n",
+      "0   4.168584  \n",
+      "1   8.602900  \n",
+      "2  10.597395  \n",
+      "3  14.240394  \n",
+      "4  31.807916  \n",
+      "digraph {v0->y;W0-> v0; W1-> v0; W2-> v0; W3-> v0; W4-> v0;Z0-> v0; Z1-> v0;W0-> y; W1-> y; W2-> y; W3-> y; W4-> y;X0-> y;}\n",
+      "\n",
+      "\n",
+      "graph[directed 1node[ id \"y\" label \"y\"]node[ id \"W0\" label \"W0\"] node[ id \"W1\" label \"W1\"] node[ id \"W2\" label \"W2\"] node[ id \"W3\" label \"W3\"] node[ id \"W4\" label \"W4\"]node[ id \"Z0\" label \"Z0\"] node[ id \"Z1\" label \"Z1\"]node[ id \"v0\" label \"v0\"]edge[source \"v0\" target \"y\"]edge[ source \"W0\" target \"v0\"] edge[ source \"W1\" target \"v0\"] edge[ source \"W2\" target \"v0\"] edge[ source \"W3\" target \"v0\"] edge[ source \"W4\" target \"v0\"]edge[ source \"Z0\" target \"v0\"] edge[ source \"Z1\" target \"v0\"]edge[ source \"W0\" target \"y\"] edge[ source \"W1\" target \"y\"] edge[ source \"W2\" target \"y\"] edge[ source \"W3\" target \"y\"] edge[ source \"W4\" target \"y\"]node[ id \"X0\" label \"X0\"] edge[ source \"X0\" target \"y\"]]\n"
+     ]
+    }
+   ],
    "source": [
     "data = dowhy.datasets.linear_dataset(beta=10,\n",
     "        num_common_causes=5,\n",
@@ -103,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,23 +142,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.view_model()"
+    "# model.view_model()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "from IPython.display import Image, display\n",
-    "display(Image(filename=\"causal_model.png\"))"
+    "# from IPython.display import Image, display\n",
+    "# display(Image(filename=\"causal_model.png\"))"
    ]
   },
   {
@@ -159,9 +183,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimand type: nonparametric-ate\n",
+      "\n",
+      "### Estimand : 1\n",
+      "Estimand name: backdoor\n",
+      "Estimand expression:\n",
+      "  d                       \n",
+      "─────(E[y|W3,W2,W0,W4,W1])\n",
+      "d[v₀]                     \n",
+      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
+      "\n",
+      "### Estimand : 2\n",
+      "Estimand name: iv\n",
+      "Estimand expression:\n",
+      " ⎡                              -1⎤\n",
+      " ⎢    d        ⎛    d          ⎞  ⎥\n",
+      "E⎢─────────(y)⋅⎜─────────([v₀])⎟  ⎥\n",
+      " ⎣d[Z₁  Z₀]    ⎝d[Z₁  Z₀]      ⎠  ⎦\n",
+      "Estimand assumption 1, As-if-random: If U→→y then ¬(U →→{Z1,Z0})\n",
+      "Estimand assumption 2, Exclusion: If we remove {Z1,Z0}→{v0}, then ¬({Z1,Z0}→y)\n",
+      "\n",
+      "### Estimand : 3\n",
+      "Estimand name: frontdoor\n",
+      "No such variable(s) found!\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "identified_estimand = model.identify_effect(proceed_when_unidentifiable=True)\n",
     "print(identified_estimand)"
@@ -183,11 +238,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "propensity_score_stratification\n",
+      "*** Causal Estimate ***\n",
+      "\n",
+      "## Identified estimand\n",
+      "Estimand type: nonparametric-ate\n",
+      "\n",
+      "### Estimand : 1\n",
+      "Estimand name: backdoor\n",
+      "Estimand expression:\n",
+      "  d                       \n",
+      "─────(E[y|W3,W2,W0,W4,W1])\n",
+      "d[v₀]                     \n",
+      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
+      "\n",
+      "## Realized estimand\n",
+      "b: y~v0+W3+W2+W0+W4+W1\n",
+      "Target units: ate\n",
+      "\n",
+      "## Estimate\n",
+      "Mean value: 10.813313102608985\n",
+      "\n",
+      "Causal Estimate is 10.813313102608985\n"
+     ]
+    }
+   ],
    "source": [
     "causal_estimate = model.estimate_effect(identified_estimand,\n",
     "        method_name=\"backdoor.propensity_score_stratification\")\n",
@@ -204,9 +288,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "propensity_score_stratification\n",
+      "*** Causal Estimate ***\n",
+      "\n",
+      "## Identified estimand\n",
+      "Estimand type: nonparametric-ate\n",
+      "\n",
+      "### Estimand : 1\n",
+      "Estimand name: backdoor\n",
+      "Estimand expression:\n",
+      "  d                       \n",
+      "─────(E[y|W3,W2,W0,W4,W1])\n",
+      "d[v₀]                     \n",
+      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
+      "\n",
+      "## Realized estimand\n",
+      "b: y~v0+W3+W2+W0+W4+W1\n",
+      "Target units: atc\n",
+      "\n",
+      "## Estimate\n",
+      "Mean value: 10.726459088224193\n",
+      "\n",
+      "Causal Estimate is 10.726459088224193\n"
+     ]
+    }
+   ],
    "source": [
     "# Causal effect on the control group (ATC)\n",
     "causal_estimate_att = model.estimate_effect(identified_estimand,\n",
@@ -225,11 +338,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:dowhy.causal_model:Causal Graph not provided. DoWhy will construct a graph based on data inputs.\n"
+     ]
+    }
+   ],
    "source": [
     "# Without graph                                       \n",
     "model= CausalModel(                             \n",
@@ -242,21 +363,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.view_model()"
+    "# model.view_model()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from IPython.display import Image, display\n",
-    "display(Image(filename=\"causal_model.png\"))"
+    "# from IPython.display import Image, display\n",
+    "# display(Image(filename=\"causal_model.png\"))"
    ]
   },
   {
@@ -270,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,9 +407,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "propensity_score_stratification\n",
+      "*** Causal Estimate ***\n",
+      "\n",
+      "## Identified estimand\n",
+      "Estimand type: nonparametric-ate\n",
+      "\n",
+      "### Estimand : 1\n",
+      "Estimand name: backdoor\n",
+      "Estimand expression:\n",
+      "  d                       \n",
+      "─────(E[y|W3,W2,W0,W4,W1])\n",
+      "d[v₀]                     \n",
+      "Estimand assumption 1, Unconfoundedness: If U→{v0} and U→y then P(y|v0,W3,W2,W0,W4,W1,U) = P(y|v0,W3,W2,W0,W4,W1)\n",
+      "\n",
+      "## Realized estimand\n",
+      "b: y~v0+W3+W2+W0+W4+W1\n",
+      "Target units: ate\n",
+      "\n",
+      "## Estimate\n",
+      "Mean value: 10.813313102608985\n",
+      "\n",
+      "Causal Estimate is 10.813313102608985\n"
+     ]
+    }
+   ],
    "source": [
     "estimate = model.estimate_effect(identified_estimand,\n",
     "                                 method_name=\"backdoor.propensity_score_stratification\")         \n",
@@ -326,11 +476,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Refute: Add a random common cause\n",
+      "Estimated effect:10.813313102608985\n",
+      "New effect:10.733524844585846\n",
+      "p value:0.28\n",
+      "\n",
+      "Wall time: 56.4 s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
+    "\n",
     "res_random=model.refute_estimate(identified_estimand, estimate, method_name=\"random_common_cause\")\n",
+    "print(res_random)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 8 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done  34 tasks      | elapsed:   15.8s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Refute: Add a random common cause\n",
+      "Estimated effect:10.813313102608985\n",
+      "New effect:10.73736604023241\n",
+      "p value:0.41999999999999993\n",
+      "\n",
+      "Wall time: 28 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=-1)]: Done 100 out of 100 | elapsed:   27.9s finished\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "res_random=model.refute_estimate(identified_estimand, estimate, \n",
+    "    method_name=\"random_common_cause\", n_jobs=-1, verbose=1)\n",
     "print(res_random)"
    ]
   },
@@ -343,12 +549,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Refute: Use a Placebo Treatment\n",
+      "Estimated effect:10.813313102608985\n",
+      "New effect:0.022048036076712393\n",
+      "p value:0.84\n",
+      "\n",
+      "Wall time: 1min 4s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
+    "\n",
     "res_placebo=model.refute_estimate(identified_estimand, estimate,\n",
     "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\")\n",
+    "print(res_placebo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 8 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done  34 tasks      | elapsed:   10.6s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Refute: Use a Placebo Treatment\n",
+      "Estimated effect:10.813313102608985\n",
+      "New effect:0.00424689283417187\n",
+      "p value:0.94\n",
+      "\n",
+      "Wall time: 22.7 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=-1)]: Done 100 out of 100 | elapsed:   22.6s finished\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "res_placebo=model.refute_estimate(identified_estimand, estimate,\n",
+    "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\", n_jobs=-1, verbose=1)\n",
     "print(res_placebo)"
    ]
   },
@@ -367,7 +629,7 @@
    "source": [
     "res_subset=model.refute_estimate(identified_estimand, estimate,\n",
     "        method_name=\"data_subset_refuter\", subset_fraction=0.9)\n",
-    "print(res_subset)\n"
+    "print(res_subset)"
    ]
   },
   {
@@ -481,11 +743,146 @@
    "source": [
     "**Conclusion**: Assuming that the unobserved confounder does not affect the treatment or outcome more strongly than any observed confounder, the causal effect can be concluded to be positive."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running Refutation Methods in Parallel\n",
+    "\n",
+    "You can spread the workload to multiple CPUs to speed up the refutation process.\n",
+    "\n",
+    "**Method 1**: Parallelize a single refutation method using the `n_jobs` parameter. For example, set `n_jobs=2` to spread the workload to two CPUs, or set `n_jobs=-1` to use all available cores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "res_placebo=model.refute_estimate(identified_estimand, estimate,\n",
+    "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\", n_jobs=-1, verbose=3)\n",
+    "print(res_placebo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Method 2**: Similarly, you can run multiple refutation methods in parallel using the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from joblib import Parallel, delayed\n",
+    "from functools import partial\n",
+    "\n",
+    "# put kwargs in dictionaries and make a list\n",
+    "kwargs_common = dict(\n",
+    "    method_name=\"random_common_cause\")\n",
+    "\n",
+    "kwargs_random = dict(\n",
+    "    method_name=\"placebo_treatment_refuter\",\n",
+    "    placebo_type=\"permute\")\n",
+    "\n",
+    "kwargs_subset = dict(\n",
+    "    method_name=\"data_subset_refuter\",\n",
+    "    subset_fraction=0.9,\n",
+    "    random_seed=1)\n",
+    "\n",
+    "\n",
+    "kwargs_list = [kwargs_common, kwargs_random, kwargs_subset]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Refute: Add a random common cause\n",
+      "Estimated effect:10.813313102608985\n",
+      "New effect:10.746344435527632\n",
+      "p value:0.48\n",
+      "\n",
+      "Refute: Use a Placebo Treatment\n",
+      "Estimated effect:10.813313102608985\n",
+      "New effect:0.030281612224610566\n",
+      "p value:0.94\n",
+      "\n",
+      "Refute: Use a subset of data\n",
+      "Estimated effect:10.813313102608985\n",
+      "New effect:10.758932868564031\n",
+      "p value:0.52\n",
+      "\n",
+      "Wall time: 1min 27s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[None, None, None]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# partial function to fix some arguments\n",
+    "refute = partial(model.refute_estimate, identified_estimand, estimate)\n",
+    "\n",
+    "# run refutation methods in parallel\n",
+    "results = Parallel(n_jobs=4)(delayed(refute)(**kwds) for kwds in kwargs_list)\n",
+    "\n",
+    "# print results\n",
+    "[print(res) for res in results]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wall time: 3min 9s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# as comparison\n",
+    "# estimate time for all refutation methods without parallelization\n",
+    "res_random = model.refute_estimate(identified_estimand, estimate, method_name=\"random_common_cause\")\n",
+    "\n",
+    "res_placebo = model.refute_estimate(identified_estimand, estimate,\n",
+    "                                    method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\")\n",
+    "                                    \n",
+    "res_subset = model.refute_estimate(identified_estimand, estimate,\n",
+    "                                   method_name=\"data_subset_refuter\", subset_fraction=0.9, random_seed=1)\n"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.7.10 ('venvrl')",
    "language": "python",
    "name": "python3"
   },
@@ -499,7 +896,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.10"
   },
   "toc": {
    "base_numbering": 1,
@@ -513,6 +910,11 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b3273f06edc005084d721bf5395ac67cca29d6f43d52ff2cb1fc0df4a110b9d3"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/example_notebooks/dowhy_simple_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_simple_example.ipynb
@@ -376,9 +376,9 @@
    "source": [
     "As you can see, the propensity score stratification estimator is reasonably robust to refutations.\n",
     "\n",
-    "**Reproducability and Parallelization**: For reproducibility, you can add a parameter \"random_seed\" to any refutation method, as shown below.\n",
+    "**Reproducability**: For reproducibility, you can add a parameter \"random_seed\" to any refutation method, as shown below.\n",
     "\n",
-    "You can also use built-in parallelization to speed up the refutation process. Simply set `n_jobs` to a value greater than 1 to spread the workload to multiple CPUs, or set `n_jobs=-1` to use all CPUs. "
+    "**Parallelization**: You can also use built-in parallelization to speed up the refutation process. Simply set `n_jobs` to a value greater than 1 to spread the workload to multiple CPUs, or set `n_jobs=-1` to use all CPUs. Currently, this is available only for `random_common_cause`, `placebo_treatment_refuter`, and `data_subset_refuter`."
    ]
   },
   {
@@ -484,100 +484,6 @@
    "source": [
     "**Conclusion**: Assuming that the unobserved confounder does not affect the treatment or outcome more strongly than any observed confounder, the causal effect can be concluded to be positive."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Running Refutation Methods in Parallel\n",
-    "\n",
-    "You can spread the workload to multiple CPUs to speed up the refutation process.\n",
-    "\n",
-    "**Method 1**: Parallelize a single refutation method using the `n_jobs` parameter. For example, set `n_jobs=2` to spread the workload to two CPUs, or set `n_jobs=-1` to use all available cores."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "res_placebo=model.refute_estimate(identified_estimand, estimate,\n",
-    "        method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\", n_jobs=-1, verbose=3)\n",
-    "print(res_placebo)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Method 2**: Similarly, you can run multiple refutation methods in parallel using the code below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from joblib import Parallel, delayed\n",
-    "from functools import partial\n",
-    "\n",
-    "# put kwargs in dictionaries and make a list\n",
-    "kwargs_common = dict(\n",
-    "    method_name=\"random_common_cause\")\n",
-    "\n",
-    "kwargs_random = dict(\n",
-    "    method_name=\"placebo_treatment_refuter\",\n",
-    "    placebo_type=\"permute\")\n",
-    "\n",
-    "kwargs_subset = dict(\n",
-    "    method_name=\"data_subset_refuter\",\n",
-    "    subset_fraction=0.9,\n",
-    "    random_seed=1)\n",
-    "\n",
-    "\n",
-    "kwargs_list = [kwargs_common, kwargs_random, kwargs_subset]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "# partial function to fix some arguments\n",
-    "refute = partial(model.refute_estimate, identified_estimand, estimate)\n",
-    "\n",
-    "# run refutation methods in parallel\n",
-    "results = Parallel(n_jobs=4, verbose=10)(delayed(refute)(**kwds) for kwds in kwargs_list)\n",
-    "\n",
-    "# print results\n",
-    "[print(res) for res in results]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "# as comparison\n",
-    "# estimate time for all refutation methods without parallelization\n",
-    "res_random = model.refute_estimate(identified_estimand, estimate, method_name=\"random_common_cause\")\n",
-    "\n",
-    "res_placebo = model.refute_estimate(identified_estimand, estimate,\n",
-    "                                    method_name=\"placebo_treatment_refuter\", placebo_type=\"permute\")\n",
-    "                                    \n",
-    "res_subset = model.refute_estimate(identified_estimand, estimate,\n",
-    "                                   method_name=\"data_subset_refuter\", subset_fraction=0.9, random_seed=1)\n"
-   ]
   }
  ],
  "metadata": {
@@ -610,6 +516,11 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b3273f06edc005084d721bf5395ac67cca29d6f43d52ff2cb1fc0df4a110b9d3"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/example_notebooks/dowhy_simple_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_simple_example.ipynb
@@ -516,11 +516,6 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "b3273f06edc005084d721bf5395ac67cca29d6f43d52ff2cb1fc0df4a110b9d3"
-   }
   }
  },
  "nbformat": 4,

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -11,6 +11,8 @@ class CausalRefuter:
 
     Subclasses implement specific refutations methods.
 
+    # todo: add docstring for common parameters here and remove from child refuter classes
+
     """
     # Default value for the number of simulations to be conducted
     DEFAULT_NUM_SIMULATIONS = 100
@@ -24,12 +26,8 @@ class CausalRefuter:
         self._random_seed = None
 
         # joblib params for parallel processing
-        # is here the right place for them?
-        # could be packed into a dict too and then **dict since they are used together
         self._n_jobs = kwargs.pop('n_jobs', None)
         self._verbose = kwargs.pop('verbose', 0)
-        self._prefer = kwargs.pop('prefer', None)
-        self._require = kwargs.pop('require', None)
 
         if "random_seed" in kwargs:
             self._random_seed = kwargs['random_seed']

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -23,6 +23,14 @@ class CausalRefuter:
         self._outcome_name = self._target_estimand.outcome_variable
         self._random_seed = None
 
+        # joblib params for parallel processing
+        # is here the right place for them?
+        # could be packed into a dict too and then **dict since they are used together
+        self._n_jobs = kwargs.pop('n_jobs', None)
+        self._verbose = kwargs.pop('verbose', 0)
+        self._prefer = kwargs.pop('prefer', None)
+        self._require = kwargs.pop('require', None)
+
         if "random_seed" in kwargs:
             self._random_seed = kwargs['random_seed']
             np.random.seed(self._random_seed)

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -9,7 +9,7 @@ from dowhy.causal_estimator import CausalEstimator
 class DataSubsetRefuter(CausalRefuter):
     """Refute an estimate by rerunning it on a random subset of the original data.
 
-    Supports additional parameters that can be specified in the refute_estimate() method.
+    Supports additional parameters that can be specified in the refute_estimate() method. For joblib-related parameters (n_jobs, verbose), please refer to the joblib documentation for more details (https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html).
 
     :param subset_fraction: Fraction of the data to be used for re-estimation, which is ``DataSubsetRefuter.DEFAULT_SUBSET_FRACTION`` by default. 
     :type  subset_fraction: float, optional 
@@ -18,7 +18,13 @@ class DataSubsetRefuter(CausalRefuter):
     :type num_simulations: int, optional    
     
     :param random_state: The seed value to be added if we wish to repeat the same random behavior. If we with to repeat the same behavior we push the same seed in the psuedo-random generator
-    :type random_state: int, RandomState, optional    
+    :type random_state: int, RandomState, optional   
+
+    :param n_jobs: The maximum number of concurrently running jobs. If -1 all CPUs are used. If 1 is given, no parallel computing code is used at all (this is the default).
+    :type n_jobs: int, optional
+
+    :param verbose: The verbosity level: if non zero, progress messages are printed. Above 50, the output is sent to stdout. The frequency of the messages increases with the verbosity level. If it more than 10, all iterations are reported. The default is 0.
+    :type verbose: int, optional 
     """
     # The default subset of the data to be used
     DEFAULT_SUBSET_FRACTION = 0.8
@@ -53,9 +59,7 @@ class DataSubsetRefuter(CausalRefuter):
         # Run refutation in parallel
         sample_estimates = Parallel(
             n_jobs=self._n_jobs,
-            verbose=self._verbose,
-            prefer=self._prefer,
-            require=self._require
+            verbose=self._verbose
         )(delayed(refute_once)() for _ in range(self._num_simulations))
         sample_estimates = np.array(sample_estimates)
 

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -14,7 +14,7 @@ from dowhy.utils.api import parse_state
 class PlaceboTreatmentRefuter(CausalRefuter):
     """Refute an estimate by replacing treatment with a randomly-generated placebo variable.
 
-    Supports additional parameters that can be specified in the refute_estimate() method. For joblib-related parameters (n_jobs, verbose, prefer, require), please refer to the joblib documentation for more details (https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html).
+    Supports additional parameters that can be specified in the refute_estimate() method. For joblib-related parameters (n_jobs, verbose), please refer to the joblib documentation for more details (https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html).
 
     :param placebo_type: Default is to generate random values for the treatment. If placebo_type is "permute", then the original treatment values are permuted by row.
     :type placebo_type: str, optional
@@ -25,20 +25,11 @@ class PlaceboTreatmentRefuter(CausalRefuter):
     :param random_state: The seed value to be added if we wish to repeat the same random behavior. If we want to repeat the same behavior we push the same seed in the psuedo-random generator.
     :type random_state: int, RandomState, optional
 
-    # now the joblib parameters are saved in base CausalRefuter class in its init method
-    # but should their description still be here? CausalRefuter init method doesn't have a docstring
     :param n_jobs: The maximum number of concurrently running jobs. If -1 all CPUs are used. If 1 is given, no parallel computing code is used at all (this is the default).
-    :type n_jobs: int, optional, default: None
+    :type n_jobs: int, optional
 
     :param verbose: The verbosity level: if non zero, progress messages are printed. Above 50, the output is sent to stdout. The frequency of the messages increases with the verbosity level. If it more than 10, all iterations are reported. The default is 0.
     :type verbose: int, optional
-
-    # are below two descriptions good enough, don't feel like I understand this fully but using wording from joblib docs again
-    :param prefer: Soft hint to choose the default backend. The default process-based backend is 'loky' and the default thread-based backend is 'threading'.
-    :type prefer: str in {'processes', 'threads'}, optional
-
-    :param require: Soft hint to choose the default backend. The default process-based backend is 'loky' and the default thread-based backend is 'threading'.
-    :type require: 'sharedmem' or None, optional
     """
 
     # Default value of the p value taken for the distribution
@@ -153,9 +144,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
         # Run refutation in parallel
         sample_estimates = Parallel(
             n_jobs=self._n_jobs, 
-            verbose=self._verbose,
-            prefer=self._prefer,
-            require=self._require
+            verbose=self._verbose
         )(delayed(refute_once)() for _ in range(self._num_simulations))
         sample_estimates = np.array(sample_estimates)
 

--- a/dowhy/causal_refuters/random_common_cause.py
+++ b/dowhy/causal_refuters/random_common_cause.py
@@ -12,6 +12,8 @@ class RandomCommonCause(CausalRefuter):
     """Refute an estimate by introducing a randomly generated confounder
     (that may have been unobserved).
 
+    Supports additional parameters that can be specified in the refute_estimate() method. For joblib-related parameters (n_jobs, verbose), please refer to the joblib documentation for more details (https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html).
+
     :param num_simulations: The number of simulations to be run, which is ``CausalRefuter.DEFAULT_NUM_SIMULATIONS`` by default
     :type num_simulations: int, optional
 
@@ -55,9 +57,7 @@ class RandomCommonCause(CausalRefuter):
         # Run refutation in parallel
         sample_estimates = Parallel(
             n_jobs=self._n_jobs,
-            verbose=self._verbose,
-            prefer=self._prefer,
-            require=self._require
+            verbose=self._verbose
         )(delayed(refute_once)() for _ in range(self._num_simulations))
         sample_estimates = np.array(sample_estimates)
 

--- a/dowhy/causal_refuters/random_common_cause.py
+++ b/dowhy/causal_refuters/random_common_cause.py
@@ -17,13 +17,19 @@ class RandomCommonCause(CausalRefuter):
 
     :param random_state: The seed value to be added if we wish to repeat the same random behavior. If we with to repeat the same behavior we push the same seed in the psuedo-random generator
     :type random_state: int, RandomState, optional
+
+    :param n_jobs: The maximum number of concurrently running jobs. If -1 all CPUs are used. If 1 is given, no parallel computing code is used at all (this is the default).
+    :type n_jobs: int, optional
+
+    :param verbose: The verbosity level: if non zero, progress messages are printed. Above 50, the output is sent to stdout. The frequency of the messages increases with the verbosity level. If it more than 10, all iterations are reported. The default is 0.
+    :type verbose: int, optional
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._num_simulations = kwargs.pop("num_simulations", CausalRefuter.DEFAULT_NUM_SIMULATIONS )
         self._random_state = kwargs.pop("random_state", None)
         self._n_jobs = kwargs.get('n_jobs', None)
-        self._verbose = kwargs.pop('verbose', False)
+        self._verbose = kwargs.pop('verbose', 0)
 
         self.logger = logging.getLogger(__name__)
 
@@ -50,6 +56,7 @@ class RandomCommonCause(CausalRefuter):
 
         sample_estimates = Parallel(n_jobs=self._n_jobs, verbose=self._verbose)(
             delayed(refute_once)() for _ in range(self._num_simulations))
+        sample_estimates = np.array(sample_estimates)
 
         refute = CausalRefutation(
             self._estimate.value,

--- a/dowhy/causal_refuters/random_common_cause.py
+++ b/dowhy/causal_refuters/random_common_cause.py
@@ -28,8 +28,6 @@ class RandomCommonCause(CausalRefuter):
         super().__init__(*args, **kwargs)
         self._num_simulations = kwargs.pop("num_simulations", CausalRefuter.DEFAULT_NUM_SIMULATIONS )
         self._random_state = kwargs.pop("random_state", None)
-        self._n_jobs = kwargs.get('n_jobs', None)
-        self._verbose = kwargs.pop('verbose', 0)
 
         self.logger = logging.getLogger(__name__)
 
@@ -54,8 +52,13 @@ class RandomCommonCause(CausalRefuter):
             new_effect = new_estimator.estimate_effect()
             return new_effect.value
 
-        sample_estimates = Parallel(n_jobs=self._n_jobs, verbose=self._verbose)(
-            delayed(refute_once)() for _ in range(self._num_simulations))
+        # Run refutation in parallel
+        sample_estimates = Parallel(
+            n_jobs=self._n_jobs,
+            verbose=self._verbose,
+            prefer=self._prefer,
+            require=self._require
+        )(delayed(refute_once)() for _ in range(self._num_simulations))
         sample_estimates = np.array(sample_estimates)
 
         refute = CausalRefutation(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ networkx>=2.0
 sympy>=1.4
 scikit-learn
 pydot>=1.4
-joblib>=1.0.0 # version? using 1.0.0
+joblib>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ networkx>=2.0
 sympy>=1.4
 scikit-learn
 pydot>=1.4
+joblib>=1.0.0 # version? using 1.0.0


### PR DESCRIPTION
Hi @amit-sharma,

I've added parallelization to the random cause and the placebo refuter using `joblib`. 

Please let me know what you think of my implementation before I do the same with the rest. For example do you have a suggestion about how to avoid the inner function within `refute_estimate` which is not overly pretty imo. 

I also added to the Getting Started Notebook. Hope this is a good start for the feature.