### PR TITLE
Fixed warnings arising in estimators and refuters

### DIFF
--- a/docs/source/getting_started/intro.rst
+++ b/docs/source/getting_started/intro.rst
@@ -74,7 +74,7 @@ DoWhy supports two formats for providing the causal graph: `gml <https://github.
 
     # IV. Refute the obtained estimate using multiple robustness checks.
     refute_results = model.refute_estimate(identified_estimand, estimate,
-                                           method_name="random_common_cause")
+                                           method_name="random_common_cause", show_progress_bar=True)
 
 DoWhy stresses on the interpretability of its output. At any point in the analysis,
 you can inspect the untested assumptions, identified estimands (if any) and the

--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -71,10 +71,15 @@ class PropensityScoreEstimator(CausalEstimator):
             raise Exception(error_msg)
 
     def _refresh_propensity_score(self):
+        '''
+            A custom estimator based on the way the propensity score estimates are to be used.
+            Invoked from the '_estimate_effect' method of various propensity score subclasses when the propensity score is not pre-computed.      
+        '''
         if self.recalculate_propensity_score is True:
             if self.propensity_score_model is None:
                 self.propensity_score_model = linear_model.LogisticRegression()
-            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
+            treatment_reshaped = np.ravel(self._treatment)
+            self.propensity_score_model.fit(self._observed_common_causes, treatment_reshaped)
             self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
         else:
             # check if user provides the propensity score column

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -1,6 +1,7 @@
 from sklearn import linear_model
 from sklearn.neighbors import NearestNeighbors
 import pandas as pd
+import numpy as np
 
 from dowhy.causal_estimator import CausalEstimate
 from dowhy.causal_estimators.propensity_score_estimator import PropensityScoreEstimator

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -386,7 +386,7 @@ class CausalModel:
                 raise NotImplementedError
         return estimate
 
-    def refute_estimate(self, estimand, estimate, method_name=None, **kwargs):
+    def refute_estimate(self, estimand, estimate, method_name=None, show_progress_bar=True, **kwargs):
         """Refute an estimated causal effect.
 
         If method_name is provided, uses the provided method. In the future, we may support automatic selection of suitable refutation tests. Following refutation methods are supported.
@@ -398,6 +398,7 @@ class CausalModel:
         :param estimand: target estimand, an instance of the IdentifiedEstimand class (typically, the output of identify_effect)
         :param estimate: estimate to be refuted, an instance of the CausalEstimate class (typically, the output of estimate_effect)
         :param method_name: name of the refutation method
+        :param show_progress_bar: Boolean flag on whether to show a progress bar
         :param kwargs:  (optional) additional arguments that are passed directly to the refutation method. Can specify a random seed here to ensure reproducible results ('random_seed' parameter). For method-specific parameters, consult the documentation for the specific method. All refutation methods are in the causal_refuters subpackage.
 
         :returns: an instance of the RefuteResult class
@@ -417,7 +418,7 @@ class CausalModel:
             estimate=estimate,
             **kwargs
         )
-        res = refuter.refute_estimate()
+        res = refuter.refute_estimate(show_progress_bar)
         return res
 
     def view_model(self, layout="dot", size=(8, 6), file_name="causal_model"):

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -208,7 +208,7 @@ class CausalRefuter:
 
         return p_value
 
-    def refute_estimate(self):
+    def refute_estimate(self, show_progress_bar=True):
         raise NotImplementedError
 
 

--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -3,6 +3,8 @@ import logging
 import numpy as np
 import pandas as pd
 import scipy.stats
+import tqdm
+from tqdm.notebook import tnrange, tqdm
 
 import math
 import statsmodels.api as sm
@@ -179,7 +181,7 @@ class AddUnobservedCommonCause(CausalRefuter):
         else:
             return np.arange(min_coeff, max_coeff, step)
 
-    def refute_estimate(self):
+    def refute_estimate(self, show_progress_bar=True):
         """
         This function attempts to add an unobserved common cause to the outcome and the treatment. At present, we have implemented the behavior for one dimensional behaviors for continuous
         and binary variables. This function can either take single valued inputs or a range of inputs. The function then looks at the data type of the input and then decides on the course of
@@ -229,7 +231,8 @@ class AddUnobservedCommonCause(CausalRefuter):
 
                 results_matrix = np.random.rand(len(self.kappa_t),len(self.kappa_y)) # Matrix to hold all the results of NxM
                 orig_data = copy.deepcopy(self._data)
-                for i in range(len(self.kappa_t)):
+
+                for i in tqdm(range(len(self.kappa_t)), colour='green', disable = not show_progress_bar, desc="Refuting Estimates: "):
                     for j in range(len(self.kappa_y)):
                         new_data = self.include_confounders_effect(orig_data, self.kappa_t[i], self.kappa_y[j])
                         new_estimator = CausalEstimator.get_estimator_object(new_data, self._target_estimand, self._estimate)
@@ -282,7 +285,7 @@ class AddUnobservedCommonCause(CausalRefuter):
                 outcomes = np.random.rand(len(self.kappa_t))
                 orig_data = copy.deepcopy(self._data)
 
-                for i in range(0,len(self.kappa_t)):
+                for i in tqdm(range(0,len(self.kappa_t)), colour='green', disable = not show_progress_bar, desc="Refuting Estimates: "):
                     new_data = self.include_confounders_effect(orig_data, self.kappa_t[i], self.kappa_y)
                     new_estimator = CausalEstimator.get_estimator_object(new_data, self._target_estimand, self._estimate)
                     new_effect = new_estimator.estimate_effect()
@@ -316,7 +319,7 @@ class AddUnobservedCommonCause(CausalRefuter):
                 outcomes = np.random.rand(len(self.kappa_y))
                 orig_data = copy.deepcopy(self._data)
 
-                for i in range(0, len(self.kappa_y)):
+                for i in tqdm(range(0,len(self.kappa_y)), colour='green', disable = not show_progress_bar, desc="Refuting Estimates: "):
                     new_data = self.include_confounders_effect(orig_data, self.kappa_t, self.kappa_y[i])
                     new_estimator = CausalEstimator.get_estimator_object(new_data, self._target_estimand, self._estimate)
                     new_effect = new_estimator.estimate_effect()

--- a/dowhy/causal_refuters/bootstrap_refuter.py
+++ b/dowhy/causal_refuters/bootstrap_refuter.py
@@ -5,6 +5,9 @@ import random
 from sklearn.utils import resample
 import logging
 
+import tqdm
+from tqdm.notebook import tnrange, tqdm
+
 class BootstrapRefuter(CausalRefuter):
     """
     Refute an estimate by running it on a random sample of the data containing measurement error in the 
@@ -82,7 +85,7 @@ class BootstrapRefuter(CausalRefuter):
             raise ValueError("Probability of Flip cannot be greater than 1")
 
     
-    def refute_estimate(self, *args, **kwargs):
+    def refute_estimate(self, show_progess_bar=True, *args, **kwargs):
         if self._sample_size > len(self._data):
                 self.logger.warning("The sample size is larger than the population size")
 
@@ -92,7 +95,7 @@ class BootstrapRefuter(CausalRefuter):
                          ,self._sample_size )
                         ) 
         
-        for index in range(self._num_simulations):
+        for index in tqdm(range(self._num_simulations), colour='green', disable = not show_progress_bar, desc="Refuting Estimates: "):
             if self._random_state is None:
                 new_data = resample(self._data, 
                                 n_samples=self._sample_size )

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -1,7 +1,10 @@
-from dowhy.causal_refuter import CausalRefuter, CausalRefutation
-from dowhy.causal_estimator import CausalEstimator
 import numpy as np
 import logging
+import tqdm
+from tqdm.notebook import tnrange, tqdm
+
+from dowhy.causal_refuter import CausalRefuter, CausalRefutation
+from dowhy.causal_estimator import CausalEstimator
 
 class DataSubsetRefuter(CausalRefuter):
     """Refute an estimate by rerunning it on a random subset of the original data.
@@ -28,7 +31,7 @@ class DataSubsetRefuter(CausalRefuter):
 
         self.logger = logging.getLogger(__name__)
 
-    def refute_estimate(self):
+    def refute_estimate(self, show_progress_bar=True):
 
         sample_estimates = np.zeros(self._num_simulations)
         self.logger.info("Refutation over {} simulated datasets of size {} each"
@@ -36,7 +39,7 @@ class DataSubsetRefuter(CausalRefuter):
                          ,self._subset_fraction*len(self._data.index) )
                         )
 
-        for index in range(self._num_simulations):
+        for index in tqdm(range(self._num_simulations), colour='green', disable = not show_progress_bar, desc="Simulating"):
             if self._random_state is None:
                 new_data = self._data.sample(frac=self._subset_fraction)
             else:

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -3,6 +3,8 @@ import math
 import numpy as np
 import pandas as pd
 import logging
+import tqdm
+from tqdm.notebook import tnrange, tqdm
 import pdb
 from collections import OrderedDict, namedtuple
 from dowhy.causal_refuter import CausalRefutation
@@ -214,7 +216,7 @@ class DummyOutcomeRefuter(CausalRefuter):
         self._outcome_name_str = self._outcome_name[0]
         self.logger = logging.getLogger(__name__)
 
-    def refute_estimate(self):
+    def refute_estimate(self, show_progress_bar=True):
 
         # We need to change the identified estimand
         # We thus, make a copy. This is done as we don't want
@@ -238,7 +240,7 @@ class DummyOutcomeRefuter(CausalRefuter):
         # Train and the Validation Datasets. Thus, we run the simulation loop followed by the training and the validation
         # loops. Thus, we can get different values everytime we get the estimator.
 
-        for _ in range( self._num_simulations ):
+        for index in tqdm(range(self._num_simulations), colour='green', disable = not show_progress_bar, desc="Refuting Estimates: "):
             estimates = []
 
             if estimator_present == False:

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -1,5 +1,6 @@
 import copy
-
+import tqdm
+from tqdm.notebook import tnrange, tqdm
 import numpy as np
 import pandas as pd
 import logging
@@ -44,7 +45,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
         self.logger = logging.getLogger(__name__)
 
 
-    def refute_estimate(self):
+    def refute_estimate(self, show_progress_bar=True):
         # only permute is supported for iv methods
         if self._target_estimand.identifier_method.startswith("iv"):
             if self._placebo_type != "permute":
@@ -75,7 +76,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
         treatment_name = self._treatment_name[0] # Extract the name of the treatment variable
         type_dict = dict( self._data.dtypes )
 
-        for index in range(self._num_simulations):
+        for index in tqdm(range(self._num_simulations), colour='green', disable = not show_progress_bar, desc="Refuting Estimates: "):
 
             if self._placebo_type == "permute":
                 permuted_idx = None

--- a/dowhy/causal_refuters/random_common_cause.py
+++ b/dowhy/causal_refuters/random_common_cause.py
@@ -1,5 +1,6 @@
 import copy
-
+import tqdm
+from tqdm.notebook import tnrange, tqdm
 import numpy as np
 import logging
 
@@ -24,7 +25,7 @@ class RandomCommonCause(CausalRefuter):
 
         self.logger = logging.getLogger(__name__)
 
-    def refute_estimate(self):
+    def refute_estimate(self, show_progress_bar=True):
         num_rows = self._data.shape[0]
         sample_estimates = np.zeros(self._num_simulations)
         self.logger.info("Refutation over {} simulated datasets, each with a random common cause added"
@@ -34,7 +35,7 @@ class RandomCommonCause(CausalRefuter):
         identified_estimand = copy.deepcopy(self._target_estimand)
         # Adding a new backdoor variable to the identified estimand
         identified_estimand.set_backdoor_variables(new_backdoor_variables)
-        for index in range(self._num_simulations):
+        for index in tqdm(range(self._num_simulations), colour='green', disable = not show_progress_bar, desc="Refuting Estimates: "):
             if self._random_state is None:
                 new_data = self._data.assign(w_random=np.random.randn(num_rows))
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ networkx>=2.0
 sympy>=1.4
 scikit-learn
 pydot>=1.4
+tqdm>=4.64.0


### PR DESCRIPTION
I have fixed the warning arising due to a mismatch of shape in regression models. This affected the estimators and refuters. There might be some more warnings still persisting but can be fixed on the go. 