### PR TITLE
Display main as main-branch in docs version selector

### DIFF
--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -2,7 +2,7 @@
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">
     <span class="fa fa-book"> Other Versions</span>
-    v: {{ current_version.name if current_version.name != "master" else "master-branch" }}
+    v: {{ current_version.name if current_version.name != "main" else "main-branch" }}
     <span class="fa fa-caret-down"></span>
   </span>
     <div class="rst-other-versions">


### PR DESCRIPTION
Forgot to update this in the previous PR.