### PR TITLE
Add Google Analytics

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -20,6 +20,7 @@ jobs:
           pip3 install 'scikit-learn==1.0.2' --force-reinstall
           if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt --use-deprecated=legacy-resolver; fi
           pip install 'numpy<=1.21' --force-reinstall
+          pip install 'git+https://github.com/petergtz/googleanalytics.git@master'
       - name: Build
         run: |
           # sphinx-multiversion invokes git internally. Its call to "git rev-parse --show-toplevel" throws the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,10 @@ extensions = [
     'nbsphinx',
     'sphinx_rtd_theme',
     "sphinx_multiversion",
+    'sphinxcontrib.googleanalytics',
 ]
+
+googleanalytics_id = 'G-B139P18WHM'
 
 autodoc_mock_imports = ['matplotlib', 'causalml', 'pymc3', 'econml']
 


### PR DESCRIPTION
Title says it all. This addresses:
- https://github.com/py-why/dowhy/issues/588.

I'm using a fork of the original sphinxcontrib-googleanalytics package, which has a small change: https://github.com/petergtz/googleanalytics/commit/f32bcb8c0fb74bf284652b9a5c154337e20058b9

It looks like the original code does not call Google Analytics correctly. I'll see if I can contribute a change back upstream.