### PR TITLE
Add support for controlled direct treatment effect

### DIFF
--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -224,15 +224,20 @@ class CausalGraph:
         observed_nodes = [node for node in self._graph.nodes() if self._graph.nodes[node]["observed"] == "yes"]
         return self._graph.subgraph(observed_nodes)
 
-    def do_surgery(self, node_names, remove_outgoing_edges=False, remove_incoming_edges=False):
+    def do_surgery(self, node_names, remove_outgoing_edges=False, remove_incoming_edges=False,
+            remove_only_direct_edges=False, target_node_names=None):
         node_names = parse_state(node_names)
         new_graph = self._graph.copy()
         for node_name in node_names:
             if remove_outgoing_edges:
-                children = new_graph.successors(node_name)
-                edges_bunch = [(node_name, child) for child in children]
-                new_graph.remove_edges_from(edges_bunch)
+                if remove_only_direct_edges:
+                    new_graph.remove_edges_from([(node_name, v) for v in target_node_names])
+                else:
+                    children = new_graph.successors(node_name)
+                    edges_bunch = [(node_name, child) for child in children]
+                    new_graph.remove_edges_from(edges_bunch)
             if remove_incoming_edges:
+                # remove_only_direct_edges is not implemented for incoming edges
                 parents = new_graph.predecessors(node_name)
                 edges_bunch = [(parent, node_name) for parent in parents]
                 new_graph.remove_edges_from(edges_bunch)

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -230,7 +230,7 @@ class CausalGraph:
         remove_outgoing_edges=False,
         remove_incoming_edges=False,
         target_node_names=None,
-        remove_only_direct_edges_to_target=False
+        remove_only_direct_edges_to_target=False,
     ):
         """Method to create a new graph based on the concept of do-surgery.
 

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -229,21 +229,32 @@ class CausalGraph:
         node_names,
         remove_outgoing_edges=False,
         remove_incoming_edges=False,
-        remove_only_direct_edges=False,
         target_node_names=None,
+        remove_only_direct_edges_to_target=False
     ):
+        """Method to create a new graph based on the concept of do-surgery.
+
+        :param node_names: focal nodes for the surgery
+        :param remove_outgoing_edges: whether to remove outgoing edges from the focal nodes
+        :param remove_incoming_edges: whether to remove incoming edges to the focal nodes
+        :param target_node_names: target nodes (optional) for the surgery, only used when remove_only_direct_edges_to_target is True
+        :param remove_only_direct_edges_to_target: whether to remove only the direct edges from focal nodes to the target nodes
+
+        :returns: a new networkx graph after the specified removal of edges
+        """
+
         node_names = parse_state(node_names)
         new_graph = self._graph.copy()
         for node_name in node_names:
             if remove_outgoing_edges:
-                if remove_only_direct_edges:
+                if remove_only_direct_edges_to_target:
                     new_graph.remove_edges_from([(node_name, v) for v in target_node_names])
                 else:
                     children = new_graph.successors(node_name)
                     edges_bunch = [(node_name, child) for child in children]
                     new_graph.remove_edges_from(edges_bunch)
             if remove_incoming_edges:
-                # remove_only_direct_edges is not implemented for incoming edges
+                # removal of only direct edges wrt a target is not implemented for incoming edges
                 parents = new_graph.predecessors(node_name)
                 edges_bunch = [(parent, node_name) for parent in parents]
                 new_graph.remove_edges_from(edges_bunch)

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -224,8 +224,14 @@ class CausalGraph:
         observed_nodes = [node for node in self._graph.nodes() if self._graph.nodes[node]["observed"] == "yes"]
         return self._graph.subgraph(observed_nodes)
 
-    def do_surgery(self, node_names, remove_outgoing_edges=False, remove_incoming_edges=False,
-            remove_only_direct_edges=False, target_node_names=None):
+    def do_surgery(
+        self,
+        node_names,
+        remove_outgoing_edges=False,
+        remove_incoming_edges=False,
+        remove_only_direct_edges=False,
+        target_node_names=None,
+    ):
         node_names = parse_state(node_names)
         new_graph = self._graph.copy()
         for node_name in node_names:

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -16,6 +16,7 @@ class CausalIdentifier:
     Currently supports backdoor and instrumental variable identification methods. The identification is based on the causal graph provided.
 
     """
+
     # Average total effect
     NONPARAMETRIC_ATE = "nonparametric-ate"
     # Natural direct effect
@@ -331,12 +332,7 @@ class CausalIdentifier:
         return estimand
 
     def identify_backdoor(
-        self,
-        treatment_name,
-        outcome_name,
-        include_unobserved=False,
-        dseparation_algo="default",
-        direct_effect = False
+        self, treatment_name, outcome_name, include_unobserved=False, dseparation_algo="default", direct_effect=False
     ):
         backdoor_sets = []
         backdoor_paths = None
@@ -344,10 +340,12 @@ class CausalIdentifier:
         if dseparation_algo == "naive":
             backdoor_paths = self._graph.get_backdoor_paths(treatment_name, outcome_name)
         elif dseparation_algo == "default":
-            bdoor_graph = self._graph.do_surgery(treatment_name,
-                    target_node_names = outcome_name,
-                    remove_outgoing_edges=True,
-                    remove_only_direct_edges=direct_effect)
+            bdoor_graph = self._graph.do_surgery(
+                treatment_name,
+                target_node_names=outcome_name,
+                remove_outgoing_edges=True,
+                remove_only_direct_edges=direct_effect,
+            )
         else:
             raise ValueError(f"d-separation algorithm {dseparation_algo} is not supported")
         method_name = (

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -195,7 +195,7 @@ class CausalIdentifier:
         return estimand
 
     def identify_cde_effect(self):
-        """ Identify controlled direct effect. For a definition, see Vanderwheele (2011).
+        """Identify controlled direct effect. For a definition, see Vanderwheele (2011).
         Controlled direct and mediated effects: definition, identification and bounds.
         https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4193506/
 

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -195,6 +195,15 @@ class CausalIdentifier:
         return estimand
 
     def identify_cde_effect(self):
+        """ Identify controlled direct effect. For a definition, see Vanderwheele (2011).
+        Controlled direct and mediated effects: definition, identification and bounds.
+        https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4193506/
+
+        Using do-calculus rules, identification yields a adjustment set.
+        It is based on the principle that under a graph where the direct edge from treatment
+        to outcome is removed, conditioning on the adjustment set should d-separate
+        treatment and outcome.
+        """
         estimands_dict = {}
         # Pick algorithm to compute backdoor sets according to method chosen
         backdoor_sets = self.identify_backdoor(self.treatment_name, self.outcome_name, direct_effect=True)
@@ -344,7 +353,7 @@ class CausalIdentifier:
                 treatment_name,
                 target_node_names=outcome_name,
                 remove_outgoing_edges=True,
-                remove_only_direct_edges=direct_effect,
+                remove_only_direct_edges_to_target=direct_effect,
             )
         else:
             raise ValueError(f"d-separation algorithm {dseparation_algo} is not supported")

--- a/tests/causal_identifiers/base.py
+++ b/tests/causal_identifiers/base.py
@@ -6,13 +6,14 @@ from .example_graphs import TEST_GRAPH_SOLUTIONS
 
 
 class IdentificationTestGraphSolution(object):
-    def __init__(self, graph_str, observed_variables, biased_sets, minimal_adjustment_sets, maximal_adjustment_sets):
+    def __init__(self, graph_str, observed_variables, biased_sets, minimal_adjustment_sets, maximal_adjustment_sets, direct_maximal_adjustment_sets=None):
         self.graph = CausalGraph("X", "Y", graph_str, observed_node_names=observed_variables)
         self.graph_str = graph_str
         self.observed_variables = observed_variables
         self.biased_sets = biased_sets
         self.minimal_adjustment_sets = minimal_adjustment_sets
         self.maximal_adjustment_sets = maximal_adjustment_sets
+        self.direct_maximal_adjustment_sets = maximal_adjustment_sets if direct_maximal_adjustment_sets is None else direct_maximal_adjustment_sets
 
 
 @pytest.fixture(params=TEST_GRAPH_SOLUTIONS.keys())

--- a/tests/causal_identifiers/base.py
+++ b/tests/causal_identifiers/base.py
@@ -6,14 +6,24 @@ from .example_graphs import TEST_GRAPH_SOLUTIONS
 
 
 class IdentificationTestGraphSolution(object):
-    def __init__(self, graph_str, observed_variables, biased_sets, minimal_adjustment_sets, maximal_adjustment_sets, direct_maximal_adjustment_sets=None):
+    def __init__(
+        self,
+        graph_str,
+        observed_variables,
+        biased_sets,
+        minimal_adjustment_sets,
+        maximal_adjustment_sets,
+        direct_maximal_adjustment_sets=None,
+    ):
         self.graph = CausalGraph("X", "Y", graph_str, observed_node_names=observed_variables)
         self.graph_str = graph_str
         self.observed_variables = observed_variables
         self.biased_sets = biased_sets
         self.minimal_adjustment_sets = minimal_adjustment_sets
         self.maximal_adjustment_sets = maximal_adjustment_sets
-        self.direct_maximal_adjustment_sets = maximal_adjustment_sets if direct_maximal_adjustment_sets is None else direct_maximal_adjustment_sets
+        self.direct_maximal_adjustment_sets = (
+            maximal_adjustment_sets if direct_maximal_adjustment_sets is None else direct_maximal_adjustment_sets
+        )
 
 
 @pytest.fixture(params=TEST_GRAPH_SOLUTIONS.keys())

--- a/tests/causal_identifiers/example_graphs.py
+++ b/tests/causal_identifiers/example_graphs.py
@@ -277,7 +277,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{"Z2"}],
-        direct_maximal_adjustment_sets=[{"Z2","Z1"}]
+        direct_maximal_adjustment_sets=[{"Z2", "Z1"}],
     ),
     "common_cause_of_mediator1": dict(
         graph_str="""graph[directed 1 node[id "X" label "X"]
@@ -295,7 +295,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[],
         minimal_adjustment_sets=[{"Z"}],
         maximal_adjustment_sets=[{"Z"}],
-        direct_maximal_adjustment_sets=[{"Z", "M"}]
+        direct_maximal_adjustment_sets=[{"Z", "M"}],
     ),
     "common_cause_of_mediator2": dict(
         graph_str="""graph[directed 1 node[id "X" label "X"]
@@ -313,7 +313,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[],
         minimal_adjustment_sets=[{"Z"}],
         maximal_adjustment_sets=[{"Z"}],
-        direct_maximal_adjustment_sets=[{"Z", "M"}]
+        direct_maximal_adjustment_sets=[{"Z", "M"}],
     ),
     "mbias_with_unobserved": dict(
         graph_str="""graph[directed 1 node[id "X" label "X"]
@@ -364,7 +364,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[{"M"}],
         minimal_adjustment_sets=[{"W"}],
         maximal_adjustment_sets=[{"W"}],
-        direct_maximal_adjustment_sets=[{"W", "M"}]
+        direct_maximal_adjustment_sets=[{"W", "M"}],
     ),
     "mediator-with-conf": dict(
         graph_str="""graph[directed 1 node[id "X" label "X"]
@@ -381,9 +381,9 @@ TEST_GRAPH_SOLUTIONS = {
                 edge[source "M" target "Y"]]
                 """,
         observed_variables=["X", "Y", "M", "W1", "W2"],
-        biased_sets=[{"M"}, {"M","W1"}],
+        biased_sets=[{"M"}, {"M", "W1"}],
         minimal_adjustment_sets=[{"W1"}],
         maximal_adjustment_sets=[{"W1", "W2"}],
-        direct_maximal_adjustment_sets=[{"W1", "M", "W2"}]
+        direct_maximal_adjustment_sets=[{"W1", "M", "W2"}],
     ),
 }

--- a/tests/causal_identifiers/example_graphs.py
+++ b/tests/causal_identifiers/example_graphs.py
@@ -37,6 +37,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[{"Z4"}, {"Z6"}, {"Z5"}, {"Z2"}, {"Z1"}, {"Z3"}, {"Z1", "Z3"}, {"Z2", "Z5"}, {"Z1", "Z2"}],
         minimal_adjustment_sets=[{"Z1", "Z4"}, {"Z2", "Z4"}, {"Z3", "Z4"}, {"Z5", "Z4"}],
         maximal_adjustment_sets=[{"Z1", "Z2", "Z3", "Z4", "Z5"}],
+        direct_maximal_adjustment_sets=[{"Z1", "Z2", "Z3", "Z4", "Z5", "Z6"}],
     ),
     "simple_selection_bias_graph": dict(
         graph_str="""graph[directed 1 node[id "Z1" label "Z1"]
@@ -216,6 +217,7 @@ TEST_GRAPH_SOLUTIONS = {
         ],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{"A", "B", "C", "D"}],
+        direct_maximal_adjustment_sets=[{"A", "B", "C", "D", "E"}],
     ),
     "book_of_why_game5": dict(
         graph_str="""graph[directed 1 node[id "A" label "A"]
@@ -275,6 +277,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{"Z2"}],
+        direct_maximal_adjustment_sets=[{"Z2","Z1"}]
     ),
     "common_cause_of_mediator1": dict(
         graph_str="""graph[directed 1 node[id "X" label "X"]
@@ -292,6 +295,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[],
         minimal_adjustment_sets=[{"Z"}],
         maximal_adjustment_sets=[{"Z"}],
+        direct_maximal_adjustment_sets=[{"Z", "M"}]
     ),
     "common_cause_of_mediator2": dict(
         graph_str="""graph[directed 1 node[id "X" label "X"]
@@ -309,6 +313,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[],
         minimal_adjustment_sets=[{"Z"}],
         maximal_adjustment_sets=[{"Z"}],
+        direct_maximal_adjustment_sets=[{"Z", "M"}]
     ),
     "mbias_with_unobserved": dict(
         graph_str="""graph[directed 1 node[id "X" label "X"]
@@ -343,5 +348,42 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets=[{"Z"}],
         minimal_adjustment_sets=[],
         maximal_adjustment_sets=[],
+    ),
+    "mediator": dict(
+        graph_str="""graph[directed 1 node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "M" label "M"]
+                node[id "W" label "W"]
+                edge[source "X" target "Y"]
+                edge[source "W" target "X"]
+                edge[source "W" target "Y"]
+                edge[source "X" target "M"]
+                edge[source "M" target "Y"]]
+                """,
+        observed_variables=["X", "Y", "M", "W"],
+        biased_sets=[{"M"}],
+        minimal_adjustment_sets=[{"W"}],
+        maximal_adjustment_sets=[{"W"}],
+        direct_maximal_adjustment_sets=[{"W", "M"}]
+    ),
+    "mediator-with-conf": dict(
+        graph_str="""graph[directed 1 node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "M" label "M"]
+                node[id "W1" label "W1"]
+                node[id "W2" label "W2"]
+                edge[source "X" target "Y"]
+                edge[source "W1" target "X"]
+                edge[source "W1" target "Y"]
+                edge[source "W2" target "M"]
+                edge[source "W2" target "Y"]
+                edge[source "X" target "M"]
+                edge[source "M" target "Y"]]
+                """,
+        observed_variables=["X", "Y", "M", "W1", "W2"],
+        biased_sets=[{"M"}, {"M","W1"}],
+        minimal_adjustment_sets=[{"W1"}],
+        maximal_adjustment_sets=[{"W1", "W2"}],
+        direct_maximal_adjustment_sets=[{"W1", "M", "W2"}]
     ),
 }

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -45,7 +45,10 @@ class TestBackdoorIdentification(object):
         graph = example_graph_solution.graph
         expected_sets = example_graph_solution.minimal_adjustment_sets
         identifier = CausalIdentifier(
-            graph, estimand_type="nonparametric-ate", method_name="minimal-adjustment", proceed_when_unidentifiable=False
+            graph,
+            estimand_type="nonparametric-ate",
+            method_name="minimal-adjustment",
+            proceed_when_unidentifiable=False,
         )
 
         backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
@@ -61,7 +64,10 @@ class TestBackdoorIdentification(object):
         graph = example_graph_solution.graph
         expected_sets = example_graph_solution.maximal_adjustment_sets
         identifier = CausalIdentifier(
-            graph, estimand_type="nonparametric-ate", method_name="maximal-adjustment", proceed_when_unidentifiable=False
+            graph,
+            estimand_type="nonparametric-ate",
+            method_name="maximal-adjustment",
+            proceed_when_unidentifiable=False,
         )
 
         backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
@@ -78,7 +84,10 @@ class TestBackdoorIdentification(object):
         graph = example_graph_solution.graph
         expected_sets = example_graph_solution.direct_maximal_adjustment_sets
         identifier = CausalIdentifier(
-            graph, estimand_type="nonparametric-cde", method_name="maximal-adjustment", proceed_when_unidentifiable=False
+            graph,
+            estimand_type="nonparametric-cde",
+            method_name="maximal-adjustment",
+            proceed_when_unidentifiable=False,
         )
 
         backdoor_results = identifier.identify_backdoor("X", "Y", direct_effect=True)

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -10,7 +10,7 @@ class TestBackdoorIdentification(object):
     def test_identify_backdoor_no_biased_sets(self, example_graph_solution: IdentificationTestGraphSolution):
         graph = example_graph_solution.graph
         biased_sets = example_graph_solution.biased_sets
-        identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
+        identifier = CausalIdentifier(graph, estimand_type="nonparametric-ate", method_name="exhaustive-search")
 
         backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
         backdoor_sets = [
@@ -28,7 +28,7 @@ class TestBackdoorIdentification(object):
     ):
         graph = example_graph_solution.graph
         observed_variables = example_graph_solution.observed_variables
-        identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
+        identifier = CausalIdentifier(graph, estimand_type="nonparametric-ate", method_name="exhaustive-search")
 
         backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
         backdoor_sets = [
@@ -45,7 +45,7 @@ class TestBackdoorIdentification(object):
         graph = example_graph_solution.graph
         expected_sets = example_graph_solution.minimal_adjustment_sets
         identifier = CausalIdentifier(
-            graph, "nonparametric-ate", method_name="minimal-adjustment", proceed_when_unidentifiable=False
+            graph, estimand_type="nonparametric-ate", method_name="minimal-adjustment", proceed_when_unidentifiable=False
         )
 
         backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
@@ -61,10 +61,27 @@ class TestBackdoorIdentification(object):
         graph = example_graph_solution.graph
         expected_sets = example_graph_solution.maximal_adjustment_sets
         identifier = CausalIdentifier(
-            graph, "nonparametric-ate", method_name="maximal-adjustment", proceed_when_unidentifiable=False
+            graph, estimand_type="nonparametric-ate", method_name="maximal-adjustment", proceed_when_unidentifiable=False
         )
 
         backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
+
+        backdoor_sets = [set(backdoor_result_dict["backdoor_set"]) for backdoor_result_dict in backdoor_results]
+        print(backdoor_sets, expected_sets, example_graph_solution.graph_str)
+        assert (
+            (len(backdoor_sets) == 0) and (len(expected_sets) == 0)
+        ) or all(  # No adjustments exist and that's expected.
+            [set(expected_set) in backdoor_sets for expected_set in expected_sets]
+        )
+
+    def test_identify_backdoor_maximal_direct_effect(self, example_graph_solution: IdentificationTestGraphSolution):
+        graph = example_graph_solution.graph
+        expected_sets = example_graph_solution.direct_maximal_adjustment_sets
+        identifier = CausalIdentifier(
+            graph, estimand_type="nonparametric-cde", method_name="maximal-adjustment", proceed_when_unidentifiable=False
+        )
+
+        backdoor_results = identifier.identify_backdoor("X", "Y", direct_effect=True)
 
         backdoor_sets = [set(backdoor_result_dict["backdoor_set"]) for backdoor_result_dict in backdoor_results]
         print(backdoor_sets, expected_sets, example_graph_solution.graph_str)


### PR DESCRIPTION
This PR adds a new estimand_type="nonparametric-cde" and associated identification method to compute the controlled direct effect. 

The estimation can still be handled using standard backdoor estimators since the estimand is always a conditional expectation.