### PR TITLE
Parameterize max_backdoor_iterations 

### DIFF
--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -51,12 +51,7 @@ class CausalIdentifier:
     DEFAULT_BACKDOOR_METHOD = BACKDOOR_DEFAULT
 
     def __init__(
-        self,
-        graph,
-        estimand_type,
-        max_backdoor_iterations,
-        method_name="default",
-        proceed_when_unidentifiable=False,
+        self, graph, estimand_type, max_backdoor_iterations, method_name="default", proceed_when_unidentifiable=False,
     ):
         self._graph = graph
         self.estimand_type = estimand_type
@@ -65,7 +60,7 @@ class CausalIdentifier:
         self.method_name = method_name
         self._proceed_when_unidentifiable = proceed_when_unidentifiable
         self.logger = logging.getLogger(__name__)
-        self.max_backdoor_iterations=max_backdoor_iterations
+        self.max_backdoor_iterations = max_backdoor_iterations
 
     def identify_effect(self, optimize_backdoor=False, costs=None, conditional_node_names=None):
         """Main method that returns an identified estimand (if one exists).
@@ -86,16 +81,11 @@ class CausalIdentifier:
         if not self._graph.has_directed_path(self.treatment_name, self.outcome_name):
             self.logger.warn("No directed path from treatment to outcome. Causal Effect is zero.")
             return IdentifiedEstimand(
-                self,
-                treatment_variable=self.treatment_name,
-                outcome_variable=self.outcome_name,
-                no_directed_path=True,
+                self, treatment_variable=self.treatment_name, outcome_variable=self.outcome_name, no_directed_path=True,
             )
         if self.estimand_type == CausalIdentifier.NONPARAMETRIC_ATE:
             return self.identify_ate_effect(
-                optimize_backdoor=optimize_backdoor,
-                costs=costs,
-                conditional_node_names=conditional_node_names,
+                optimize_backdoor=optimize_backdoor, costs=costs, conditional_node_names=conditional_node_names,
             )
         elif self.estimand_type == CausalIdentifier.NONPARAMETRIC_NDE:
             return self.identify_nde_effect()
@@ -146,10 +136,7 @@ class CausalIdentifier:
         self.logger.info("Instrumental variables for treatment and outcome:" + str(instrument_names))
         if len(instrument_names) > 0:
             iv_estimand_expr = self.construct_iv_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                instrument_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, instrument_names,
             )
             self.logger.debug("Identified expression = " + str(iv_estimand_expr))
             estimands_dict["iv"] = iv_estimand_expr
@@ -162,10 +149,7 @@ class CausalIdentifier:
         self.logger.info("Frontdoor variables for treatment and outcome:" + str(frontdoor_variables_names))
         if len(frontdoor_variables_names) > 0:
             frontdoor_estimand_expr = self.construct_frontdoor_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                frontdoor_variables_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, frontdoor_variables_names,
             )
             self.logger.debug("Identified expression = " + str(frontdoor_estimand_expr))
             estimands_dict["frontdoor"] = frontdoor_estimand_expr
@@ -255,10 +239,7 @@ class CausalIdentifier:
         self.logger.info("Mediators for treatment and outcome:" + str(mediators_names))
         if len(mediators_names) > 0:
             mediation_estimand_expr = self.construct_mediation_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                mediators_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, mediators_names,
             )
             self.logger.debug("Identified expression = " + str(mediation_estimand_expr))
             estimands_dict["mediation"] = mediation_estimand_expr
@@ -308,10 +289,7 @@ class CausalIdentifier:
         self.logger.info("Mediators for treatment and outcome:" + str(mediators_names))
         if len(mediators_names) > 0:
             mediation_estimand_expr = self.construct_mediation_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                mediators_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, mediators_names,
             )
             self.logger.debug("Identified expression = " + str(mediation_estimand_expr))
             estimands_dict["mediation"] = mediation_estimand_expr
@@ -471,11 +449,7 @@ class CausalIdentifier:
         """
         if costs is None and self.method_name == "efficient-mincost-adjustment":
             self.logger.warning("No costs were passed, so they will be assumed to be constant and equal to 1.")
-        efficient_bd = EfficientBackdoor(
-            graph=self._graph,
-            conditional_node_names=conditional_node_names,
-            costs=costs,
-        )
+        efficient_bd = EfficientBackdoor(graph=self._graph, conditional_node_names=conditional_node_names, costs=costs,)
         if self.method_name == "efficient-adjustment":
             backdoor_set = efficient_bd.optimal_adj_set()
             backdoor_sets = [{"backdoor_set": tuple(backdoor_set)}]
@@ -500,7 +474,7 @@ class CausalIdentifier:
         max_iterations,
     ):
         num_iterations = 0
-        is_max_iterated=False
+        is_max_iterated = False
         found_valid_adjustment_set = False
         all_nodes_observed = self._graph.all_observed(self._graph.get_all_nodes())
         # If `minimal-adjustment` method is specified, start the search from the set with minimum size. Otherwise, start from the largest.
@@ -512,8 +486,11 @@ class CausalIdentifier:
         for size_candidate_set in set_sizes:
             for candidate_set in itertools.combinations(filt_eligible_variables, size_candidate_set):
                 num_iterations += 1
-                if ((method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE) or (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)) and num_iterations > max_iterations:
-                    is_max_iterated=True
+                if (
+                    (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)
+                    or (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)
+                ) and num_iterations > max_iterations:
+                    is_max_iterated = True
                     break
                 check = self._graph.check_valid_backdoor_set(
                     treatment_name,
@@ -532,11 +509,7 @@ class CausalIdentifier:
             # If the backdoor method is `maximal-adjustment` or `minimal-adjustment`, return the first found adjustment set.
             if (
                 method_name
-                in {
-                    CausalIdentifier.BACKDOOR_DEFAULT,
-                    CausalIdentifier.BACKDOOR_MAX,
-                    CausalIdentifier.BACKDOOR_MIN,
-                }
+                in {CausalIdentifier.BACKDOOR_DEFAULT, CausalIdentifier.BACKDOOR_MAX, CausalIdentifier.BACKDOOR_MIN,}
                 and found_valid_adjustment_set
             ):
                 break
@@ -575,12 +548,7 @@ class CausalIdentifier:
         return default_key
 
     def build_backdoor_estimands_dict(
-        self,
-        treatment_name,
-        outcome_name,
-        backdoor_sets,
-        estimands_dict,
-        proceed_when_unidentifiable=None,
+        self, treatment_name, outcome_name, backdoor_sets, estimands_dict, proceed_when_unidentifiable=None,
     ):
         """Build the final dict for backdoor sets by filtering unobserved variables if needed."""
         backdoor_variables_dict = {}
@@ -679,10 +647,7 @@ class CausalIdentifier:
         # For simplicity, assuming a one-variable mediation set
         for candidate_var in eligible_variables:
             is_valid_mediation = self._graph.check_valid_mediation_set(
-                self.treatment_name,
-                self.outcome_name,
-                parse_state(candidate_var),
-                mediation_paths=mediation_paths,
+                self.treatment_name, self.outcome_name, parse_state(candidate_var), mediation_paths=mediation_paths,
             )
             self.logger.debug(
                 "Candidate mediation set: {0}, on_mediating_path: {1}".format(candidate_var, is_valid_mediation)
@@ -699,11 +664,7 @@ class CausalIdentifier:
         estimands_dict = {}
         backdoor_sets = self.identify_backdoor(treatment_name, mediators_names)
         estimands_dict, backdoor_variables_dict = self.build_backdoor_estimands_dict(
-            treatment_name,
-            mediators_names,
-            backdoor_sets,
-            estimands_dict,
-            proceed_when_unidentifiable=True,
+            treatment_name, mediators_names, backdoor_sets, estimands_dict, proceed_when_unidentifiable=True,
         )
         # Setting default "backdoor" identification adjustment set
         default_backdoor_id = self.get_default_backdoor_set_id(backdoor_variables_dict)
@@ -716,11 +677,7 @@ class CausalIdentifier:
         estimands_dict = {}
         backdoor_sets = self.identify_backdoor(mediators_names, outcome_name)
         estimands_dict, backdoor_variables_dict = self.build_backdoor_estimands_dict(
-            mediators_names,
-            outcome_name,
-            backdoor_sets,
-            estimands_dict,
-            proceed_when_unidentifiable=True,
+            mediators_names, outcome_name, backdoor_sets, estimands_dict, proceed_when_unidentifiable=True,
         )
         # Setting default "backdoor" identification adjustment set
         default_backdoor_id = self.get_default_backdoor_set_id(backdoor_variables_dict)
@@ -795,9 +752,7 @@ class CausalIdentifier:
         sym_effect = spstats.Expectation(sym_treatment_derivative * sym_outcome_derivative)
         sym_assumptions = {
             "Full-mediation": ("{2} intercepts (blocks) all directed paths from {0} to {1}.").format(
-                ",".join(treatment_name),
-                ",".join(outcome_name),
-                ",".join(frontdoor_variables_names),
+                ",".join(treatment_name), ",".join(outcome_name), ",".join(frontdoor_variables_names),
             ),
             "First-stage-unconfoundedness": (
                 "If U\N{RIGHTWARDS ARROW}{{{0}}} and U\N{RIGHTWARDS ARROW}{{{1}}}" " then P({1}|{0},U) = P({1}|{0})"
@@ -805,11 +760,7 @@ class CausalIdentifier:
             "Second-stage-unconfoundedness": (
                 "If U\N{RIGHTWARDS ARROW}{{{2}}} and U\N{RIGHTWARDS ARROW}{1}"
                 " then P({1}|{2}, {0}, U) = P({1}|{2}, {0})"
-            ).format(
-                ",".join(treatment_name),
-                outcome_name,
-                ",".join(frontdoor_variables_names),
-            ),
+            ).format(",".join(treatment_name), outcome_name, ",".join(frontdoor_variables_names),),
         }
 
         estimand = {"estimand": sym_effect, "assumptions": sym_assumptions}
@@ -818,10 +769,7 @@ class CausalIdentifier:
     def construct_mediation_estimand(self, estimand_type, treatment_name, outcome_name, mediators_names):
         # TODO: support multivariate treatments better.
         expr = None
-        if estimand_type in (
-            CausalIdentifier.NONPARAMETRIC_NDE,
-            CausalIdentifier.NONPARAMETRIC_NIE,
-        ):
+        if estimand_type in (CausalIdentifier.NONPARAMETRIC_NDE, CausalIdentifier.NONPARAMETRIC_NIE,):
             outcome_name = outcome_name[0]
             sym_outcome = spstats.Normal(outcome_name, 0, 1)
             sym_treatment_symbols = [spstats.Normal(t, 0, 1) for t in treatment_name]
@@ -845,11 +793,7 @@ class CausalIdentifier:
             sym_assumptions = {
                 "Mediation": (
                     "{2} intercepts (blocks) all directed paths from {0} to {1} except the path {{{0}}}\N{RIGHTWARDS ARROW}{{{1}}}."
-                ).format(
-                    ",".join(treatment_name),
-                    ",".join(outcome_name),
-                    ",".join(mediators_names),
-                ),
+                ).format(",".join(treatment_name), ",".join(outcome_name), ",".join(mediators_names),),
                 "First-stage-unconfoundedness": (
                     "If U\N{RIGHTWARDS ARROW}{{{0}}} and U\N{RIGHTWARDS ARROW}{{{1}}}" " then P({1}|{0},U) = P({1}|{0})"
                 ).format(",".join(treatment_name), ",".join(mediators_names)),
@@ -861,8 +805,7 @@ class CausalIdentifier:
         else:
             raise ValueError(
                 "Estimand type not supported. Supported estimand types are {0} or {1}'.".format(
-                    CausalIdentifier.NONPARAMETRIC_NDE,
-                    CausalIdentifier.NONPARAMETRIC_NIE,
+                    CausalIdentifier.NONPARAMETRIC_NDE, CausalIdentifier.NONPARAMETRIC_NIE,
                 )
             )
 

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -512,7 +512,7 @@ class CausalIdentifier:
         for size_candidate_set in set_sizes:
             for candidate_set in itertools.combinations(filt_eligible_variables, size_candidate_set):
                 num_iterations += 1
-                if num_iterations > max_iterations:
+                if ((method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE) or (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)) and num_iterations > max_iterations:
                     is_max_iterated=True
                     break
                 check = self._graph.check_valid_backdoor_set(
@@ -529,9 +529,6 @@ class CausalIdentifier:
                 if check["is_dseparated"]:
                     backdoor_sets.append({"backdoor_set": candidate_set})
                     found_valid_adjustment_set = True
-                if method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE and num_iterations > max_iterations:
-                    is_max_iterated=True
-                    break
             # If the backdoor method is `maximal-adjustment` or `minimal-adjustment`, return the first found adjustment set.
             if (
                 method_name

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -179,12 +179,13 @@ class CausalModel:
         return self._graph
 
     def identify_effect(
-        self, estimand_type=None, method_name="default", proceed_when_unidentifiable=None, optimize_backdoor=False
+        self, estimand_type=None, method_name="default", proceed_when_unidentifiable=None, max_backdoor_iterations=100000,optimize_backdoor=False
     ):
         """Identify the causal effect to be estimated, using properties of the causal graph.
 
         :param method_name: Method name for identification algorithm. ("id-algorithm" or "default")
         :param proceed_when_unidentifiable: Binary flag indicating whether identification should proceed in the presence of (potential) unobserved confounders.
+        :param max_backdoor_iterations: Number of valid combination adjustment sets we have to iterate over to overall find best adjustment set
         :returns: a probability expression (estimand) for the causal effect if identified, else NULL
 
         """
@@ -200,7 +201,7 @@ class CausalModel:
             identified_estimand = self.identifier.identify_effect()
         else:
             self.identifier = CausalIdentifier(
-                self._graph, estimand_type, method_name, proceed_when_unidentifiable=proceed_when_unidentifiable
+                self._graph, estimand_type, max_backdoor_iterations,method_name, proceed_when_unidentifiable=proceed_when_unidentifiable
             )
             identified_estimand = self.identifier.identify_effect(optimize_backdoor=optimize_backdoor)
 

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -179,7 +179,12 @@ class CausalModel:
         return self._graph
 
     def identify_effect(
-        self, estimand_type=None, method_name="default", proceed_when_unidentifiable=None, max_backdoor_iterations=100000,optimize_backdoor=False
+        self,
+        estimand_type=None,
+        method_name="default",
+        proceed_when_unidentifiable=None,
+        max_backdoor_iterations=100000,
+        optimize_backdoor=False,
     ):
         """Identify the causal effect to be estimated, using properties of the causal graph.
 
@@ -201,7 +206,11 @@ class CausalModel:
             identified_estimand = self.identifier.identify_effect()
         else:
             self.identifier = CausalIdentifier(
-                self._graph, estimand_type, max_backdoor_iterations,method_name, proceed_when_unidentifiable=proceed_when_unidentifiable
+                self._graph,
+                estimand_type,
+                max_backdoor_iterations,
+                method_name,
+                proceed_when_unidentifiable=proceed_when_unidentifiable,
             )
             identified_estimand = self.identifier.identify_effect(optimize_backdoor=optimize_backdoor)
 


### PR DESCRIPTION
Hi team, this PR mainly exposes the max_backdoor_iterations parameter to the user.
Made necessary changes to causal_model.py and causal_identifier.py files.

**Why we need to parameterize max_backdoor_iterations?**
Currently, max_backdoor_iterations, which now would be one of a parameter in identify_effect method is a private variable in CausalIdentifier.py file.
Defaulted to a static value of 100000, it makes sure to perform up till 100000 networkx.d_seperated operations un till a valid adjustment set of co-variates are found.
https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.d_separation.d_separated.html
For a one-time activity of looping - 100K could be fine, but generally if we have a large causal graph, we don't just end up in estimating only one variables effect in other variable. We would perform many trails by back-and-forth selecting many variables as treatments and outcomes.

For each of these trails, because of statically coded 100K max_backdoor_iterations, we would perform 100k networkx.d_seperated tests.
Due to this reason, we would like to parameterize max_backdoor_iterations, such that an end-user now can retrieve results faster with regulation on number of backdoor_iterations.

**Code changes and Logic:**
causal_model.py ->
Added max_backdoor_iterations as one of a parameter to the identify_effect method and defaulted a value of 100000.
copied max_backdoor_iterations variable and added as one of a parameter into CausalIdentifier method call.

causal_identifier.py ->
Removed previous hardcoded private variable: MAX_BACKDOOR_ITERATIONS
Added max_backdoor_iterations as one of a parameter to the CausalIdentifier method and initialized it to a self object.
changed everywhere in file's code from MAX_BACKDOOR_ITERATIONS to self.max_backdoor_iterations
Implemented a logic to check on every iteration, whether #number_of_iterations is greater than max_backdoor_iterations. If yes - breaks from the loop, else - continues.

**New enhancement but with previous code Logic:**
Step-0: max_backdoor_iterations=25000
Step-1: nx.d_seperated method stopped executing 320000th time.
Step-2: if 320000>10000
Step-3: breaks from the loop
(why d_seperated logic should execute many combinations whilst user request only for 25K times)
Note: 320000 is a number, which I've observed from the itertools.combination() method

**New enhancement with newest code Logic:**
Step-0: max_backdoor_iterations=25000
Step-1: Check #no_iter>max_iter for every inner loop-thru
Step-2: nx.d_seperated method getting stopped at 25000th time.
Step-3: if 25000>25000
Step-4: breaks from the loop

Please let me know in case of any questions.
Chaitanya Molabanti