### PR TITLE
Parameterize max_backdoor_iterations

### DIFF
--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -364,13 +364,7 @@ class CausalGraph:
             parents_2 = self.get_parents(node)
             for parent in parents_2:
                 if parent not in nodes1:
-                    causes_2 = causes_2.union(
-                        set(
-                            [
-                                parent,
-                            ]
-                        )
-                    )
+                    causes_2 = causes_2.union(set([parent,]))
                     causes_2 = causes_2.union(self.get_ancestors(parent))
         return list(causes_1.intersection(causes_2))
 

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -51,12 +51,7 @@ class CausalIdentifier:
     DEFAULT_BACKDOOR_METHOD = BACKDOOR_DEFAULT
 
     def __init__(
-        self,
-        graph,
-        estimand_type,
-        max_backdoor_iterations,
-        method_name="default",
-        proceed_when_unidentifiable=False,
+        self, graph, estimand_type, max_backdoor_iterations, method_name="default", proceed_when_unidentifiable=False,
     ):
         self._graph = graph
         self.estimand_type = estimand_type
@@ -65,7 +60,7 @@ class CausalIdentifier:
         self.method_name = method_name
         self._proceed_when_unidentifiable = proceed_when_unidentifiable
         self.logger = logging.getLogger(__name__)
-        self.max_backdoor_iterations=max_backdoor_iterations
+        self.max_backdoor_iterations = max_backdoor_iterations
 
     def identify_effect(self, optimize_backdoor=False, costs=None, conditional_node_names=None):
         """Main method that returns an identified estimand (if one exists).
@@ -86,16 +81,11 @@ class CausalIdentifier:
         if not self._graph.has_directed_path(self.treatment_name, self.outcome_name):
             self.logger.warn("No directed path from treatment to outcome. Causal Effect is zero.")
             return IdentifiedEstimand(
-                self,
-                treatment_variable=self.treatment_name,
-                outcome_variable=self.outcome_name,
-                no_directed_path=True,
+                self, treatment_variable=self.treatment_name, outcome_variable=self.outcome_name, no_directed_path=True,
             )
         if self.estimand_type == CausalIdentifier.NONPARAMETRIC_ATE:
             return self.identify_ate_effect(
-                optimize_backdoor=optimize_backdoor,
-                costs=costs,
-                conditional_node_names=conditional_node_names,
+                optimize_backdoor=optimize_backdoor, costs=costs, conditional_node_names=conditional_node_names,
             )
         elif self.estimand_type == CausalIdentifier.NONPARAMETRIC_NDE:
             return self.identify_nde_effect()
@@ -146,10 +136,7 @@ class CausalIdentifier:
         self.logger.info("Instrumental variables for treatment and outcome:" + str(instrument_names))
         if len(instrument_names) > 0:
             iv_estimand_expr = self.construct_iv_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                instrument_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, instrument_names,
             )
             self.logger.debug("Identified expression = " + str(iv_estimand_expr))
             estimands_dict["iv"] = iv_estimand_expr
@@ -162,10 +149,7 @@ class CausalIdentifier:
         self.logger.info("Frontdoor variables for treatment and outcome:" + str(frontdoor_variables_names))
         if len(frontdoor_variables_names) > 0:
             frontdoor_estimand_expr = self.construct_frontdoor_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                frontdoor_variables_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, frontdoor_variables_names,
             )
             self.logger.debug("Identified expression = " + str(frontdoor_estimand_expr))
             estimands_dict["frontdoor"] = frontdoor_estimand_expr
@@ -255,10 +239,7 @@ class CausalIdentifier:
         self.logger.info("Mediators for treatment and outcome:" + str(mediators_names))
         if len(mediators_names) > 0:
             mediation_estimand_expr = self.construct_mediation_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                mediators_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, mediators_names,
             )
             self.logger.debug("Identified expression = " + str(mediation_estimand_expr))
             estimands_dict["mediation"] = mediation_estimand_expr
@@ -308,10 +289,7 @@ class CausalIdentifier:
         self.logger.info("Mediators for treatment and outcome:" + str(mediators_names))
         if len(mediators_names) > 0:
             mediation_estimand_expr = self.construct_mediation_estimand(
-                self.estimand_type,
-                self._graph.treatment_name,
-                self._graph.outcome_name,
-                mediators_names,
+                self.estimand_type, self._graph.treatment_name, self._graph.outcome_name, mediators_names,
             )
             self.logger.debug("Identified expression = " + str(mediation_estimand_expr))
             estimands_dict["mediation"] = mediation_estimand_expr
@@ -471,11 +449,7 @@ class CausalIdentifier:
         """
         if costs is None and self.method_name == "efficient-mincost-adjustment":
             self.logger.warning("No costs were passed, so they will be assumed to be constant and equal to 1.")
-        efficient_bd = EfficientBackdoor(
-            graph=self._graph,
-            conditional_node_names=conditional_node_names,
-            costs=costs,
-        )
+        efficient_bd = EfficientBackdoor(graph=self._graph, conditional_node_names=conditional_node_names, costs=costs,)
         if self.method_name == "efficient-adjustment":
             backdoor_set = efficient_bd.optimal_adj_set()
             backdoor_sets = [{"backdoor_set": tuple(backdoor_set)}]
@@ -500,7 +474,7 @@ class CausalIdentifier:
         max_iterations,
     ):
         num_iterations = 0
-        is_max_iterated=False
+        is_max_iterated = False
         found_valid_adjustment_set = False
         all_nodes_observed = self._graph.all_observed(self._graph.get_all_nodes())
         # If `minimal-adjustment` method is specified, start the search from the set with minimum size. Otherwise, start from the largest.
@@ -512,8 +486,11 @@ class CausalIdentifier:
         for size_candidate_set in set_sizes:
             for candidate_set in itertools.combinations(filt_eligible_variables, size_candidate_set):
                 num_iterations += 1
-                if ((method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE) or (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)) and num_iterations > max_iterations:
-                    is_max_iterated=True
+                if (
+                    (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)
+                    or (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)
+                ) and num_iterations > max_iterations:
+                    is_max_iterated = True
                     break
                 check = self._graph.check_valid_backdoor_set(
                     treatment_name,
@@ -532,11 +509,7 @@ class CausalIdentifier:
             # If the backdoor method is `maximal-adjustment` or `minimal-adjustment`, return the first found adjustment set.
             if (
                 method_name
-                in {
-                    CausalIdentifier.BACKDOOR_DEFAULT,
-                    CausalIdentifier.BACKDOOR_MAX,
-                    CausalIdentifier.BACKDOOR_MIN,
-                }
+                in {CausalIdentifier.BACKDOOR_DEFAULT, CausalIdentifier.BACKDOOR_MAX, CausalIdentifier.BACKDOOR_MIN,}
                 and found_valid_adjustment_set
             ):
                 break
@@ -575,12 +548,7 @@ class CausalIdentifier:
         return default_key
 
     def build_backdoor_estimands_dict(
-        self,
-        treatment_name,
-        outcome_name,
-        backdoor_sets,
-        estimands_dict,
-        proceed_when_unidentifiable=None,
+        self, treatment_name, outcome_name, backdoor_sets, estimands_dict, proceed_when_unidentifiable=None,
     ):
         """Build the final dict for backdoor sets by filtering unobserved variables if needed."""
         backdoor_variables_dict = {}
@@ -679,10 +647,7 @@ class CausalIdentifier:
         # For simplicity, assuming a one-variable mediation set
         for candidate_var in eligible_variables:
             is_valid_mediation = self._graph.check_valid_mediation_set(
-                self.treatment_name,
-                self.outcome_name,
-                parse_state(candidate_var),
-                mediation_paths=mediation_paths,
+                self.treatment_name, self.outcome_name, parse_state(candidate_var), mediation_paths=mediation_paths,
             )
             self.logger.debug(
                 "Candidate mediation set: {0}, on_mediating_path: {1}".format(candidate_var, is_valid_mediation)
@@ -699,11 +664,7 @@ class CausalIdentifier:
         estimands_dict = {}
         backdoor_sets = self.identify_backdoor(treatment_name, mediators_names)
         estimands_dict, backdoor_variables_dict = self.build_backdoor_estimands_dict(
-            treatment_name,
-            mediators_names,
-            backdoor_sets,
-            estimands_dict,
-            proceed_when_unidentifiable=True,
+            treatment_name, mediators_names, backdoor_sets, estimands_dict, proceed_when_unidentifiable=True,
         )
         # Setting default "backdoor" identification adjustment set
         default_backdoor_id = self.get_default_backdoor_set_id(backdoor_variables_dict)
@@ -716,11 +677,7 @@ class CausalIdentifier:
         estimands_dict = {}
         backdoor_sets = self.identify_backdoor(mediators_names, outcome_name)
         estimands_dict, backdoor_variables_dict = self.build_backdoor_estimands_dict(
-            mediators_names,
-            outcome_name,
-            backdoor_sets,
-            estimands_dict,
-            proceed_when_unidentifiable=True,
+            mediators_names, outcome_name, backdoor_sets, estimands_dict, proceed_when_unidentifiable=True,
         )
         # Setting default "backdoor" identification adjustment set
         default_backdoor_id = self.get_default_backdoor_set_id(backdoor_variables_dict)
@@ -795,9 +752,7 @@ class CausalIdentifier:
         sym_effect = spstats.Expectation(sym_treatment_derivative * sym_outcome_derivative)
         sym_assumptions = {
             "Full-mediation": ("{2} intercepts (blocks) all directed paths from {0} to {1}.").format(
-                ",".join(treatment_name),
-                ",".join(outcome_name),
-                ",".join(frontdoor_variables_names),
+                ",".join(treatment_name), ",".join(outcome_name), ",".join(frontdoor_variables_names),
             ),
             "First-stage-unconfoundedness": (
                 "If U\N{RIGHTWARDS ARROW}{{{0}}} and U\N{RIGHTWARDS ARROW}{{{1}}}" " then P({1}|{0},U) = P({1}|{0})"
@@ -805,11 +760,7 @@ class CausalIdentifier:
             "Second-stage-unconfoundedness": (
                 "If U\N{RIGHTWARDS ARROW}{{{2}}} and U\N{RIGHTWARDS ARROW}{1}"
                 " then P({1}|{2}, {0}, U) = P({1}|{2}, {0})"
-            ).format(
-                ",".join(treatment_name),
-                outcome_name,
-                ",".join(frontdoor_variables_names),
-            ),
+            ).format(",".join(treatment_name), outcome_name, ",".join(frontdoor_variables_names),),
         }
 
         estimand = {"estimand": sym_effect, "assumptions": sym_assumptions}
@@ -818,10 +769,7 @@ class CausalIdentifier:
     def construct_mediation_estimand(self, estimand_type, treatment_name, outcome_name, mediators_names):
         # TODO: support multivariate treatments better.
         expr = None
-        if estimand_type in (
-            CausalIdentifier.NONPARAMETRIC_NDE,
-            CausalIdentifier.NONPARAMETRIC_NIE,
-        ):
+        if estimand_type in (CausalIdentifier.NONPARAMETRIC_NDE, CausalIdentifier.NONPARAMETRIC_NIE,):
             outcome_name = outcome_name[0]
             sym_outcome = spstats.Normal(outcome_name, 0, 1)
             sym_treatment_symbols = [spstats.Normal(t, 0, 1) for t in treatment_name]
@@ -845,11 +793,7 @@ class CausalIdentifier:
             sym_assumptions = {
                 "Mediation": (
                     "{2} intercepts (blocks) all directed paths from {0} to {1} except the path {{{0}}}\N{RIGHTWARDS ARROW}{{{1}}}."
-                ).format(
-                    ",".join(treatment_name),
-                    ",".join(outcome_name),
-                    ",".join(mediators_names),
-                ),
+                ).format(",".join(treatment_name), ",".join(outcome_name), ",".join(mediators_names),),
                 "First-stage-unconfoundedness": (
                     "If U\N{RIGHTWARDS ARROW}{{{0}}} and U\N{RIGHTWARDS ARROW}{{{1}}}" " then P({1}|{0},U) = P({1}|{0})"
                 ).format(",".join(treatment_name), ",".join(mediators_names)),
@@ -861,8 +805,7 @@ class CausalIdentifier:
         else:
             raise ValueError(
                 "Estimand type not supported. Supported estimand types are {0} or {1}'.".format(
-                    CausalIdentifier.NONPARAMETRIC_NDE,
-                    CausalIdentifier.NONPARAMETRIC_NIE,
+                    CausalIdentifier.NONPARAMETRIC_NDE, CausalIdentifier.NONPARAMETRIC_NIE,
                 )
             )
 

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -512,7 +512,7 @@ class CausalIdentifier:
         for size_candidate_set in set_sizes:
             for candidate_set in itertools.combinations(filt_eligible_variables, size_candidate_set):
                 num_iterations += 1
-                if num_iterations > max_iterations:
+                if ((method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE) or (method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE)) and num_iterations > max_iterations:
                     is_max_iterated=True
                     break
                 check = self._graph.check_valid_backdoor_set(
@@ -529,9 +529,6 @@ class CausalIdentifier:
                 if check["is_dseparated"]:
                     backdoor_sets.append({"backdoor_set": candidate_set})
                     found_valid_adjustment_set = True
-                if method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE and num_iterations > max_iterations:
-                    is_max_iterated=True
-                    break
             # If the backdoor method is `maximal-adjustment` or `minimal-adjustment`, return the first found adjustment set.
             if (
                 method_name

--- a/dowhy/causal_identifiers/efficient_backdoor.py
+++ b/dowhy/causal_identifiers/efficient_backdoor.py
@@ -94,9 +94,7 @@ class EfficientBackdoor:
         causal_vertices = set()
         causal_paths = list(
             nx.all_simple_paths(
-                self.graph._graph,
-                source=self.graph.treatment_name[0],
-                target=self.graph.outcome_name[0],
+                self.graph._graph, source=self.graph.treatment_name[0], target=self.graph.outcome_name[0],
             )
         )
 
@@ -250,9 +248,7 @@ class EfficientBackdoor:
         """
         D = self.build_D()
         _, flow_dict = nx.algorithms.flow.maximum_flow(
-            flowG=D,
-            _s=self.graph.outcome_name[0] + "''",
-            _t=self.graph.treatment_name[0] + "'",
+            flowG=D, _s=self.graph.outcome_name[0] + "''", _t=self.graph.treatment_name[0] + "'",
         )
         queu = [self.graph.outcome_name[0] + "''"]
         S_c = set()

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -179,12 +179,13 @@ class CausalModel:
         return self._graph
 
     def identify_effect(
-        self, estimand_type=None, method_name="default", proceed_when_unidentifiable=None, optimize_backdoor=False
+        self, estimand_type=None, method_name="default", proceed_when_unidentifiable=None, max_backdoor_iterations=100000,optimize_backdoor=False
     ):
         """Identify the causal effect to be estimated, using properties of the causal graph.
 
         :param method_name: Method name for identification algorithm. ("id-algorithm" or "default")
         :param proceed_when_unidentifiable: Binary flag indicating whether identification should proceed in the presence of (potential) unobserved confounders.
+        :param max_backdoor_iterations: Number of valid combination adjustment sets we have to iterate over to overall find best adjustment set
         :returns: a probability expression (estimand) for the causal effect if identified, else NULL
 
         """
@@ -200,7 +201,7 @@ class CausalModel:
             identified_estimand = self.identifier.identify_effect()
         else:
             self.identifier = CausalIdentifier(
-                self._graph, estimand_type, method_name, proceed_when_unidentifiable=proceed_when_unidentifiable
+                self._graph, estimand_type, max_backdoor_iterations,method_name, proceed_when_unidentifiable=proceed_when_unidentifiable
             )
             identified_estimand = self.identifier.identify_effect(optimize_backdoor=optimize_backdoor)
 

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -179,7 +179,12 @@ class CausalModel:
         return self._graph
 
     def identify_effect(
-        self, estimand_type=None, method_name="default", proceed_when_unidentifiable=None, max_backdoor_iterations=100000,optimize_backdoor=False
+        self,
+        estimand_type=None,
+        method_name="default",
+        proceed_when_unidentifiable=None,
+        max_backdoor_iterations=100000,
+        optimize_backdoor=False,
     ):
         """Identify the causal effect to be estimated, using properties of the causal graph.
 
@@ -201,7 +206,11 @@ class CausalModel:
             identified_estimand = self.identifier.identify_effect()
         else:
             self.identifier = CausalIdentifier(
-                self._graph, estimand_type, max_backdoor_iterations,method_name, proceed_when_unidentifiable=proceed_when_unidentifiable
+                self._graph,
+                estimand_type,
+                max_backdoor_iterations,
+                method_name,
+                proceed_when_unidentifiable=proceed_when_unidentifiable,
             )
             identified_estimand = self.identifier.identify_effect(optimize_backdoor=optimize_backdoor)
 

--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -670,9 +670,7 @@ class AddUnobservedCommonCause(CausalRefuter):
         U = np.array(U)
         model = sm.OLS(U, X)
         results = model.fit()
-        U = U.reshape(
-            -1,
-        )
+        U = U.reshape(-1,)
         final_U = U - results.fittedvalues.values
         final_U = pd.Series(U)
 

--- a/dowhy/causal_refuters/linear_sensitivity_analyzer.py
+++ b/dowhy/causal_refuters/linear_sensitivity_analyzer.py
@@ -130,7 +130,7 @@ class LinearSensitivityAnalyzer:
 
         if np.isscalar(estimate):  # for single covariate
             t_stats = estimator_model.tvalues[treatment]
-            return t_stats**2 / (t_stats**2 + degree_of_freedom)
+            return t_stats ** 2 / (t_stats ** 2 + degree_of_freedom)
 
         else:  # compute for a group of covariates
             covariance_matrix = estimator_model.cov_params().loc[treatment, :][treatment]
@@ -166,10 +166,10 @@ class LinearSensitivityAnalyzer:
         if f_adjusted < 0:
             r_value = 0
         else:
-            r_value = 0.5 * (np.sqrt(f_adjusted**4 + (4 * f_adjusted**2)) - f_adjusted**2)
+            r_value = 0.5 * (np.sqrt(f_adjusted ** 4 + (4 * f_adjusted ** 2)) - f_adjusted ** 2)
 
         if f_adjusted > 0 and f_q > 1 / f_critical:
-            r_value = (f_q**2 - f_critical**2) / (1 + f_q**2)
+            r_value = (f_q ** 2 - f_critical ** 2) / (1 + f_q ** 2)
 
         return r_value
 
@@ -199,8 +199,8 @@ class LinearSensitivityAnalyzer:
 
         bias_adjusted_t = (bias_adjusted_estimate - self.null_hypothesis_effect) / bias_adjusted_se
 
-        bias_adjusted_partial_r2 = bias_adjusted_t**2 / (
-            bias_adjusted_t**2 + (self.degree_of_freedom - 1)
+        bias_adjusted_partial_r2 = bias_adjusted_t ** 2 / (
+            bias_adjusted_t ** 2 + (self.degree_of_freedom - 1)
         )  # partial r2 formula used with new t value and dof - 1
 
         num_se = t.ppf(
@@ -247,7 +247,7 @@ class LinearSensitivityAnalyzer:
             self.null_hypothesis_effect = self.estimate * (1 + self.percent_change_estimate)
 
         self.t_stats = (self.estimate - self.null_hypothesis_effect) / self.standard_error
-        self.partial_f2 = self.t_stats**2 / self.degree_of_freedom
+        self.partial_f2 = self.t_stats ** 2 / self.degree_of_freedom
 
         # build a new regression model by considering treatment variables as outcome
         treatment_linear_model = self.treatment_regression()
@@ -272,7 +272,7 @@ class LinearSensitivityAnalyzer:
 
             r2uwj_wt = (
                 self.frac_strength_treatment
-                * (r2twj_w**2)
+                * (r2twj_w ** 2)
                 / ((1 - self.frac_strength_treatment * r2twj_w) * (1 - r2twj_w))
             )
             if any(val >= 1 for val in r2uwj_wt):

--- a/dowhy/gcm/confidence_intervals.py
+++ b/dowhy/gcm/confidence_intervals.py
@@ -108,14 +108,18 @@ def confidence_intervals(
 
         summary_result = bootstrap_results_summary_func(np.column_stack([v for v in tmp_dict.values()]))
 
-        return {key: summary_result[i] for i, key in enumerate(tmp_dict)}, {
-            key: _estimate_percentile_bounds(np.array(tmp_dict[key]).squeeze(), confidence_level) for key in tmp_dict
-        }
+        return (
+            {key: summary_result[i] for i, key in enumerate(tmp_dict)},
+            {key: _estimate_percentile_bounds(np.array(tmp_dict[key]).squeeze(), confidence_level) for key in tmp_dict},
+        )
     else:
         all_results: np.ndarray = shape_into_2d(np.array(all_results))
 
-        return bootstrap_results_summary_func(all_results), np.array(
-            [_estimate_percentile_bounds(all_results[:, i], confidence_level) for i in range(all_results.shape[1])]
+        return (
+            bootstrap_results_summary_func(all_results),
+            np.array(
+                [_estimate_percentile_bounds(all_results[:, i], confidence_level) for i in range(all_results.shape[1])]
+            ),
         )
 
 

--- a/dowhy/gcm/independence_test/kernel.py
+++ b/dowhy/gcm/independence_test/kernel.py
@@ -235,7 +235,7 @@ def _kci(
     Z: np.ndarray,
     kernel: Callable[[np.ndarray], np.ndarray],
     scale_data: bool,
-    regularization_param: float = 10**-3,
+    regularization_param: float = 10 ** -3,
 ) -> float:
     """
     Tests the null hypothesis that X and Y are independent given Z using the kernel conditional independence test.
@@ -330,7 +330,7 @@ def _fast_centering(k: np.ndarray) -> np.ndarray:
         k
         - 1 / n * np.outer(np.ones(n), np.sum(k, axis=0))
         - 1 / n * np.outer(np.sum(k, axis=1), np.ones(n))
-        + 1 / n**2 * np.sum(k) * np.ones((n, n))
+        + 1 / n ** 2 * np.sum(k) * np.ones((n, n))
     )
     return k_c
 
@@ -379,7 +379,7 @@ def _hsic(
         * (
             np.sum(k_mat * l_mat)
             - 2 / n * np.sum(k_mat, axis=0) @ np.sum(l_mat, axis=1)
-            + 1 / n**2 * np.sum(k_mat) * np.sum(l_mat)
+            + 1 / n ** 2 * np.sum(k_mat) * np.sum(l_mat)
         )
     )
 
@@ -401,7 +401,7 @@ def _hsic(
     if test_statistic <= cut_off_value:
         test_statistic = 0
 
-    al = m_hsic**2 / var_hsic
+    al = m_hsic ** 2 / var_hsic
     bet = var_hsic * n / m_hsic
 
     p_value = 1 - gamma.cdf(test_statistic, al, scale=bet)
@@ -410,7 +410,7 @@ def _hsic(
 
 
 def _filter_out_small_eigen_values_and_vectors(
-    eigen_values: np.ndarray, eigen_vectors: np.ndarray, relative_tolerance: float = (10**-5)
+    eigen_values: np.ndarray, eigen_vectors: np.ndarray, relative_tolerance: float = (10 ** -5)
 ) -> Tuple[np.ndarray, np.ndarray]:
     filtered_indices_xz_z = np.where(eigen_values[eigen_values > max(eigen_values) * relative_tolerance])
 
@@ -422,7 +422,7 @@ def _estimate_p_value(ww_prod: np.ndarray, statistic: np.ndarray) -> float:
     mean_approx = np.trace(ww_prod)
     variance_approx = 2 * np.trace(ww_prod @ ww_prod)
 
-    alpha_approx = mean_approx**2 / variance_approx
+    alpha_approx = mean_approx ** 2 / variance_approx
     beta_approx = variance_approx / mean_approx
 
     return 1 - gamma.cdf(statistic, alpha_approx, scale=beta_approx)
@@ -540,7 +540,7 @@ def _rcit(
 
         cov_zz = _estimate_column_wise_covariances(random_features_z, random_features_z)
         inverse_cov_zz = scipy.linalg.cho_solve(
-            scipy.linalg.cho_factor(cov_zz + np.eye(cov_zz.shape[0]) * 10**-10, lower=True), np.eye(cov_zz.shape[0])
+            scipy.linalg.cho_factor(cov_zz + np.eye(cov_zz.shape[0]) * 10 ** -10, lower=True), np.eye(cov_zz.shape[0])
         )
         cov_xz = _estimate_column_wise_covariances(random_features_x, random_features_z)
         cov_zy = _estimate_column_wise_covariances(random_features_z, random_features_y)

--- a/dowhy/gcm/influence.py
+++ b/dowhy/gcm/influence.py
@@ -40,7 +40,7 @@ def arrow_strength(
     parent_samples: Optional[pd.DataFrame] = None,
     num_samples_conditional: int = 1000,
     max_num_runs: int = 5000,
-    tolerance: float = 10**-4,
+    tolerance: float = 10 ** -4,
     n_jobs: int = 1,
     difference_estimation_func: Optional[Callable[[np.ndarray, np.ndarray], Union[np.ndarray, float]]] = None,
 ) -> Dict[Tuple[Any, Any], float]:
@@ -103,7 +103,7 @@ def arrow_strength_of_model(
     input_samples: np.ndarray,
     num_samples_from_conditional: int = 1000,
     max_num_runs: int = 5000,
-    tolerance: float = 10**-4,
+    tolerance: float = 10 ** -4,
     n_jobs: int = 1,
     difference_estimation_func: Optional[Callable[[np.ndarray, np.ndarray], Union[np.ndarray, float]]] = None,
     input_subsets: Optional[List[List[int]]] = None,

--- a/dowhy/gcm/shapley.py
+++ b/dowhy/gcm/shapley.py
@@ -198,7 +198,7 @@ def _approximate_shapley_values_via_least_squares_regression(
     use_subset_approximation: bool,
     num_samples_for_approximation: int,
     n_jobs: int,
-    full_and_empty_subset_weight: float = 10**20,
+    full_and_empty_subset_weight: float = 10 ** 20,
 ) -> np.ndarray:
     """For more details about this approximation, see Section 4.1.1 in
     Janzing, D., Minorics, L., & Bloebaum, P. (2020).

--- a/dowhy/gcm/stochastic_models.py
+++ b/dowhy/gcm/stochastic_models.py
@@ -94,7 +94,7 @@ class ScipyDistribution(StochasticModel):
 
     @staticmethod
     def find_suitable_continuous_distribution(
-        distribution_samples: np.ndarray, divergence_threshold: float = 10**-2
+        distribution_samples: np.ndarray, divergence_threshold: float = 10 ** -2
     ) -> Tuple[rv_continuous, Dict[str, float]]:
         """Tries to find the best fitting continuous parametric distribution of given samples. This is done by fitting
         different parametric models and selecting the one with the smallest KL divergence between observed and generated
@@ -139,8 +139,11 @@ class ScipyDistribution(StochasticModel):
                     currently_best_parameters = params
                     currently_smallest_divergence = divergence
 
-        return currently_best_distribution, ScipyDistribution.map_scipy_distribution_parameters_to_names(
-            currently_best_distribution, currently_best_parameters
+        return (
+            currently_best_distribution,
+            ScipyDistribution.map_scipy_distribution_parameters_to_names(
+                currently_best_distribution, currently_best_parameters
+            ),
         )
 
     @staticmethod

--- a/dowhy/utils/cit.py
+++ b/dowhy/utils/cit.py
@@ -97,7 +97,7 @@ def partial_corr(data=None, x=None, y=None, z=None, method="pearson"):
 
     # Finding p-value using student T test
     dof = n - k - 2  # Degree of freedom for multivariate analysis
-    tval = r * np.sqrt(dof / (1 - r**2))  # Test statistic
+    tval = r * np.sqrt(dof / (1 - r ** 2))  # Test statistic
     pval = 2 * t.sf(np.abs(tval), dof)  # Calculate p-value corresponding to the test statistic and degree of freedom
 
     ci = compute_ci(r=r, nx=(n - k), ny=(n - k))  # Finding Confidence Interval

--- a/dowhy/utils/dgps/linear_dgp.py
+++ b/dowhy/utils/dgps/linear_dgp.py
@@ -63,18 +63,10 @@ class LinearDataGeneratingProcess(DataGeneratingProcess):
     def generation_process(self):
         self.weights["confounder=>treatment"] = self.generate_weights((len(self.confounder), len(self.treatment)))
         self.weights["confounder=>treatment"][0,] = (
-            self.weights["confounder=>treatment"][
-                0,
-            ]
-            + 100
+            self.weights["confounder=>treatment"][0,] + 100
         )  # increasing weight of the first confounder
         self.weights["confounder=>outcome"] = self.generate_weights((len(self.confounder), len(self.outcome)))
-        self.weights["confounder=>outcome"][0,] = (
-            self.weights["confounder=>outcome"][
-                0,
-            ]
-            + 100
-        )
+        self.weights["confounder=>outcome"][0,] = self.weights["confounder=>outcome"][0,] + 100
         self.weights["effect_modifier=>outcome"] = self.generate_weights((len(self.effect_modifier), len(self.outcome)))
         self.weights["treatment=>outcome"] = self.generate_weights((len(self.treatment), len(self.outcome)))
 

--- a/tests/causal_estimators/base.py
+++ b/tests/causal_estimators/base.py
@@ -103,33 +103,15 @@ class TestEstimator(object):
         self,
         tests_to_run="all",
         num_common_causes=[2, 3],
-        num_instruments=[
-            1,
-        ],
-        num_effect_modifiers=[
-            0,
-        ],
-        num_treatments=[
-            1,
-        ],
-        num_frontdoor_variables=[
-            0,
-        ],
-        treatment_is_binary=[
-            True,
-        ],
-        treatment_is_category=[
-            False,
-        ],
-        outcome_is_binary=[
-            False,
-        ],
-        confidence_intervals=[
-            False,
-        ],
-        test_significance=[
-            False,
-        ],
+        num_instruments=[1,],
+        num_effect_modifiers=[0,],
+        num_treatments=[1,],
+        num_frontdoor_variables=[0,],
+        treatment_is_binary=[True,],
+        treatment_is_category=[False,],
+        outcome_is_binary=[False,],
+        confidence_intervals=[False,],
+        test_significance=[False,],
         dataset="linear",
         method_params=None,
     ):

--- a/tests/causal_estimators/test_generalized_linear_model_estimator.py
+++ b/tests/causal_estimators/test_generalized_linear_model_estimator.py
@@ -21,31 +21,7 @@ class TestGeneralizedLinearModelEstimator(object):
             "outcome_is_binary",
             "identifier_method",
         ],
-        [
-            (
-                0.1,
-                GeneralizedLinearModelEstimator,
-                [
-                    0,
-                ],
-                [
-                    0,
-                ],
-                [
-                    0,
-                ],
-                [
-                    1,
-                ],
-                [
-                    False,
-                ],
-                [
-                    True,
-                ],
-                "backdoor",
-            )
-        ],
+        [(0.1, GeneralizedLinearModelEstimator, [0,], [0,], [0,], [1,], [False,], [True,], "backdoor",)],
     )
     def test_average_treatment_effect(
         self,
@@ -67,12 +43,8 @@ class TestGeneralizedLinearModelEstimator(object):
             num_treatments=num_treatments,
             treatment_is_binary=treatment_is_binary,
             outcome_is_binary=outcome_is_binary,
-            confidence_intervals=[
-                True,
-            ],
-            test_significance=[
-                True,
-            ],
+            confidence_intervals=[True,],
+            test_significance=[True,],
             method_params={
                 "num_simulations": 10,
                 "num_null_simulations": 10,

--- a/tests/causal_estimators/test_instrumental_variable_estimator.py
+++ b/tests/causal_estimators/test_instrumental_variable_estimator.py
@@ -22,23 +22,7 @@ class TestInstrumentalVariableEstimator(object):
             "outcome_is_binary",
             "identifier_method",
         ],
-        [
-            (
-                0.4,
-                InstrumentalVariableEstimator,
-                [0, 1],
-                [1, 2],
-                [
-                    0,
-                ],
-                [1, 2],
-                [False, True],
-                [
-                    False,
-                ],
-                "iv",
-            ),
-        ],
+        [(0.4, InstrumentalVariableEstimator, [0, 1], [1, 2], [0,], [1, 2], [False, True], [False,], "iv",),],
     )
     def test_average_treatment_effect(
         self,

--- a/tests/causal_estimators/test_linear_regression_estimator.py
+++ b/tests/causal_estimators/test_linear_regression_estimator.py
@@ -21,63 +21,9 @@ class TestLinearRegressionEstimator(object):
             "outcome_is_binary",
         ],
         [
-            (
-                0.1,
-                LinearRegressionEstimator,
-                [0, 1],
-                [0, 1],
-                [
-                    0,
-                ],
-                [1, 2],
-                [
-                    True,
-                ],
-                [
-                    False,
-                ],
-                [
-                    False,
-                ],
-            ),
-            (
-                0.1,
-                LinearRegressionEstimator,
-                [0, 1],
-                [0, 1],
-                [
-                    0,
-                ],
-                [1, 2],
-                [
-                    False,
-                ],
-                [
-                    True,
-                ],
-                [
-                    False,
-                ],
-            ),
-            (
-                0.1,
-                LinearRegressionEstimator,
-                [0, 1],
-                [0, 1],
-                [
-                    0,
-                ],
-                [1, 2],
-                [
-                    False,
-                ],
-                [
-                    False,
-                ],
-                [
-                    False,
-                ],
-            ),
+            (0.1, LinearRegressionEstimator, [0, 1], [0, 1], [0,], [1, 2], [True,], [False,], [False,],),
+            (0.1, LinearRegressionEstimator, [0, 1], [0, 1], [0,], [1, 2], [False,], [True,], [False,],),
+            (0.1, LinearRegressionEstimator, [0, 1], [0, 1], [0,], [1, 2], [False,], [False,], [False,],),
         ],
     )
     def test_average_treatment_effect(
@@ -101,11 +47,7 @@ class TestLinearRegressionEstimator(object):
             treatment_is_binary=treatment_is_binary,
             treatment_is_category=treatment_is_category,
             outcome_is_binary=outcome_is_binary,
-            confidence_intervals=[
-                True,
-            ],
-            test_significance=[
-                True,
-            ],
+            confidence_intervals=[True,],
+            test_significance=[True,],
             method_params={"num_simulations": 10, "num_null_simulations": 10},
         )

--- a/tests/causal_estimators/test_propensity_score_matching_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_matching_estimator.py
@@ -19,26 +19,7 @@ class TestPropensityScoreMatchingEstimator(object):
             "treatment_is_binary",
             "outcome_is_binary",
         ],
-        [
-            (
-                0.3,
-                PropensityScoreMatchingEstimator,
-                [1, 2],
-                [0],
-                [
-                    0,
-                ],
-                [
-                    1,
-                ],
-                [
-                    True,
-                ],
-                [
-                    False,
-                ],
-            ),
-        ],
+        [(0.3, PropensityScoreMatchingEstimator, [1, 2], [0], [0,], [1,], [True,], [False,],),],
     )
     def test_average_treatment_effect(
         self,
@@ -59,11 +40,7 @@ class TestPropensityScoreMatchingEstimator(object):
             num_treatments=num_treatments,
             treatment_is_binary=treatment_is_binary,
             outcome_is_binary=outcome_is_binary,
-            confidence_intervals=[
-                False,
-            ],
-            test_significance=[
-                False,
-            ],
+            confidence_intervals=[False,],
+            test_significance=[False,],
             method_params={"num_simulations": 10, "num_null_simulations": 10},
         )

--- a/tests/causal_estimators/test_propensity_score_stratification_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_stratification_estimator.py
@@ -19,26 +19,7 @@ class TestPropensityScoreStratificationEstimator(object):
             "treatment_is_binary",
             "outcome_is_binary",
         ],
-        [
-            (
-                0.1,
-                PropensityScoreStratificationEstimator,
-                [1, 2],
-                [0],
-                [
-                    0,
-                ],
-                [
-                    1,
-                ],
-                [
-                    True,
-                ],
-                [
-                    False,
-                ],
-            ),
-        ],
+        [(0.1, PropensityScoreStratificationEstimator, [1, 2], [0], [0,], [1,], [True,], [False,],),],
     )
     def test_average_treatment_effect(
         self,
@@ -59,11 +40,7 @@ class TestPropensityScoreStratificationEstimator(object):
             num_treatments=num_treatments,
             treatment_is_binary=treatment_is_binary,
             outcome_is_binary=outcome_is_binary,
-            confidence_intervals=[
-                True,
-            ],
-            test_significance=[
-                True,
-            ],
+            confidence_intervals=[True,],
+            test_significance=[True,],
             method_params={"num_simulations": 10, "num_null_simulations": 10},
         )

--- a/tests/causal_estimators/test_propensity_score_weighting_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_weighting_estimator.py
@@ -22,26 +22,7 @@ class TestPropensityScoreWeightingEstimator(object):
             "treatment_is_binary",
             "outcome_is_binary",
         ],
-        [
-            (
-                0.4,
-                PropensityScoreWeightingEstimator,
-                [1, 2],
-                [0],
-                [
-                    0,
-                ],
-                [
-                    1,
-                ],
-                [
-                    True,
-                ],
-                [
-                    False,
-                ],
-            ),
-        ],
+        [(0.4, PropensityScoreWeightingEstimator, [1, 2], [0], [0,], [1,], [True,], [False,],),],
     )
     def test_average_treatment_effect(
         self,
@@ -62,11 +43,7 @@ class TestPropensityScoreWeightingEstimator(object):
             num_treatments=num_treatments,
             treatment_is_binary=treatment_is_binary,
             outcome_is_binary=outcome_is_binary,
-            confidence_intervals=[
-                True,
-            ],
-            test_significance=[
-                True,
-            ],
+            confidence_intervals=[True,],
+            test_significance=[True,],
             method_params={"num_simulations": 1, "num_null_simulations": 1},
         )

--- a/tests/causal_estimators/test_regression_discontinuity_estimator.py
+++ b/tests/causal_estimators/test_regression_discontinuity_estimator.py
@@ -20,27 +20,7 @@ class TestRegressionDiscontinuityEstimator(object):
             "outcome_is_binary",
             "identifier_method",
         ],
-        [
-            (
-                0.2,
-                RegressionDiscontinuityEstimator,
-                [1],
-                [
-                    1,
-                ],
-                [0],
-                [
-                    1,
-                ],
-                [
-                    True,
-                ],
-                [
-                    False,
-                ],
-                "iv",
-            ),
-        ],
+        [(0.2, RegressionDiscontinuityEstimator, [1], [1,], [0], [1,], [True,], [False,], "iv",),],
     )
     def test_average_treatment_effect(
         self,

--- a/tests/causal_estimators/test_two_stage_regression_estimator.py
+++ b/tests/causal_estimators/test_two_stage_regression_estimator.py
@@ -20,27 +20,7 @@ class TestTwoStageRegressionEstimator(object):
             "treatment_is_binary",
             "outcome_is_binary",
         ],
-        [
-            (
-                0.1,
-                TwoStageRegressionEstimator,
-                [0],
-                [0],
-                [
-                    0,
-                ],
-                [
-                    1,
-                ],
-                [
-                    1,
-                ],
-                [False],
-                [
-                    False,
-                ],
-            ),
-        ],
+        [(0.1, TwoStageRegressionEstimator, [0], [0], [0,], [1,], [1,], [False], [False,],),],
     )
     def test_average_treatment_effect(
         self,
@@ -63,11 +43,7 @@ class TestTwoStageRegressionEstimator(object):
             num_frontdoor_variables=num_frontdoor_variables,
             treatment_is_binary=treatment_is_binary,
             outcome_is_binary=outcome_is_binary,
-            confidence_intervals=[
-                True,
-            ],
-            test_significance=[
-                False,
-            ],
+            confidence_intervals=[True,],
+            test_significance=[False,],
             method_params={"num_simulations": 10, "num_null_simulations": 10},
         )

--- a/tests/causal_identifiers/example_graphs.py
+++ b/tests/causal_identifiers/example_graphs.py
@@ -48,11 +48,7 @@ TEST_GRAPH_SOLUTIONS = {
                     edge[source "Y" target "Z1"]]
                     """,
         observed_variables=["Z1", "X", "Y"],
-        biased_sets=[
-            {
-                "Z1",
-            }
-        ],
+        biased_sets=[{"Z1",}],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{}],
     ),
@@ -66,11 +62,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables=["Z1", "X", "Y"],
         biased_sets=[],
         minimal_adjustment_sets=[{}],
-        maximal_adjustment_sets=[
-            {
-                "Z1",
-            }
-        ],
+        maximal_adjustment_sets=[{"Z1",}],
     ),
     # The following simpsons paradox examples are taken from Pearl, J {2013}. "Understanding Simpson’s Paradox" - http://ftp.cs.ucla.edu/pub/stat_ser/r414.pdf
     "pearl_simpsons_paradox_1c": dict(
@@ -86,11 +78,7 @@ TEST_GRAPH_SOLUTIONS = {
                 edge[source "L2" target "Y"]]
                 """,
         observed_variables=["Z", "X", "Y"],
-        biased_sets=[
-            {
-                "Z",
-            }
-        ],
+        biased_sets=[{"Z",}],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{}],
     ),
@@ -106,16 +94,8 @@ TEST_GRAPH_SOLUTIONS = {
                 """,
         observed_variables=["Z", "X", "Y"],
         biased_sets=[],
-        minimal_adjustment_sets=[
-            {
-                "Z",
-            }
-        ],
-        maximal_adjustment_sets=[
-            {
-                "Z",
-            }
-        ],
+        minimal_adjustment_sets=[{"Z",}],
+        maximal_adjustment_sets=[{"Z",}],
     ),
     "pearl_simpsons_paradox_2a": dict(
         graph_str="""graph[directed 1 node[id "Z" label "Z"]
@@ -128,11 +108,7 @@ TEST_GRAPH_SOLUTIONS = {
                 edge[source "L" target "Y"]]
                 """,
         observed_variables=["Z", "X", "Y"],
-        biased_sets=[
-            {
-                "Z",
-            }
-        ],
+        biased_sets=[{"Z",}],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{}],
     ),
@@ -179,12 +155,7 @@ TEST_GRAPH_SOLUTIONS = {
                 edge[source "Z3" target "Y"]]
                 """,
         observed_variables=["Z1", "Z2", "Z3", "X", "Y"],
-        biased_sets=[
-            {
-                "Z2",
-            },
-            {"Z1", "Z2"},
-        ],
+        biased_sets=[{"Z2",}, {"Z1", "Z2"},],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{"Z1", "Z2", "Z3"}],
     ),
@@ -206,15 +177,7 @@ TEST_GRAPH_SOLUTIONS = {
                 edge[source "E" target "Y"]]
                 """,
         observed_variables=["A", "B", "C", "D", "E", "X", "Y"],
-        biased_sets=[
-            {
-                "B",
-            },
-            {
-                "C",
-            },
-            {"B", "C"},
-        ],
+        biased_sets=[{"B",}, {"C",}, {"B", "C"},],
         minimal_adjustment_sets=[{}],
         maximal_adjustment_sets=[{"A", "B", "C", "D"}],
         direct_maximal_adjustment_sets=[{"A", "B", "C", "D", "E"}],
@@ -233,11 +196,7 @@ TEST_GRAPH_SOLUTIONS = {
                 edge[source "X" target "Y"]]
                 """,
         observed_variables=["A", "B", "C", "X", "Y"],
-        biased_sets=[
-            {
-                "B",
-            }
-        ],
+        biased_sets=[{"B",}],
         minimal_adjustment_sets=[{"C"}],
         maximal_adjustment_sets=[{"A", "B", "C"}],
     ),
@@ -255,11 +214,7 @@ TEST_GRAPH_SOLUTIONS = {
                 edge[source "X" target "Y"]]
                 """,
         observed_variables=["A", "B", "X", "Y"],
-        biased_sets=[
-            {
-                "B",
-            }
-        ],
+        biased_sets=[{"B",}],
         minimal_adjustment_sets=[{"A", "B"}],
         maximal_adjustment_sets=[{"A", "B"}],
     ),

--- a/tests/causal_identifiers/example_graphs_efficient.py
+++ b/tests/causal_identifiers/example_graphs_efficient.py
@@ -198,12 +198,7 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
         efficient_adjustment={"R", "T"},
         efficient_minimal_adjustment={"R", "T"},
         efficient_mincost_adjustment={"B", "Q"},
-        costs=[
-            ("B", {"cost": 1}),
-            ("Q", {"cost": 1}),
-            ("R", {"cost": 2}),
-            ("T", {"cost": 2}),
-        ],
+        costs=[("B", {"cost": 1}), ("Q", {"cost": 1}), ("R", {"cost": 2}), ("T", {"cost": 2}),],
     ),
     # A graph where optimal, optimal minimal and optimal min cost are different
     "alldiff_example_graph": dict(
@@ -237,21 +232,7 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
                         edge[source "O" target "Y"]
                         ]
                         """,
-        observed_node_names=[
-            "X",
-            "Y",
-            "K",
-            "O",
-            "W1",
-            "W2",
-            "W3",
-            "W4",
-            "W5",
-            "W6",
-            "W7",
-            "W8",
-            "W9",
-        ],
+        observed_node_names=["X", "Y", "K", "O", "W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8", "W9",],
         conditional_node_names=[],
         efficient_adjustment={"O", "W7", "W8", "W9"},
         efficient_minimal_adjustment={"W7", "W8", "W9"},
@@ -325,12 +306,7 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
             "tissue disorder",
             "neuromusc fatigue",
         },
-        efficient_minimal_adjustment={
-            "team motivation",
-            "previous injury",
-            "tissue disorder",
-            "neuromusc fatigue",
-        },
+        efficient_minimal_adjustment={"team motivation", "previous injury", "tissue disorder", "neuromusc fatigue",},
         efficient_mincost_adjustment={"team motivation", "previous injury", "fitness"},
         costs=None,
     ),

--- a/tests/causal_identifiers/test_efficient_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_efficient_backdoor_identifier.py
@@ -21,13 +21,11 @@ def test_identify_efficient_backdoor_algorithms():
             if example[method_name_results] is None:
                 with pytest.raises(ValueError):
                     ident_eff.identify_effect(
-                        costs=example["costs"],
-                        conditional_node_names=example["conditional_node_names"],
+                        costs=example["costs"], conditional_node_names=example["conditional_node_names"],
                     )
             else:
                 results_eff = ident_eff.identify_effect(
-                    costs=example["costs"],
-                    conditional_node_names=example["conditional_node_names"],
+                    costs=example["costs"], conditional_node_names=example["conditional_node_names"],
                 )
                 assert set(results_eff.get_backdoor_variables()) == example[method_name_results]
 
@@ -41,16 +39,13 @@ def test_fail_negative_costs_efficient_backdoor_algorithms():
         observed_node_names=example["observed_node_names"],
     )
     ident_eff = CausalIdentifier(
-        graph=G,
-        estimand_type="nonparametric-ate",
-        method_name="efficient-mincost-adjustment",
+        graph=G, estimand_type="nonparametric-ate", method_name="efficient-mincost-adjustment",
     )
     mod_costs = copy.deepcopy(example["costs"])
     mod_costs[0][1]["cost"] = 0
     with pytest.raises(Exception):
         ident_eff.identify_effect(
-            costs=mod_costs,
-            conditional_node_names=example["conditional_node_names"],
+            costs=mod_costs, conditional_node_names=example["conditional_node_names"],
         )
 
 
@@ -63,16 +58,13 @@ def test_fail_unobserved_cond_vars_efficient_backdoor_algorithms():
         observed_node_names=example["observed_node_names"],
     )
     ident_eff = CausalIdentifier(
-        graph=G,
-        estimand_type="nonparametric-ate",
-        method_name="efficient-mincost-adjustment",
+        graph=G, estimand_type="nonparametric-ate", method_name="efficient-mincost-adjustment",
     )
     mod_cond_names = copy.deepcopy(example["conditional_node_names"])
     mod_cond_names.append("U")
     with pytest.raises(Exception):
         ident_eff.identify_effect(
-            costs=example["costs"],
-            conditional_node_names=mod_cond_names,
+            costs=example["costs"], conditional_node_names=mod_cond_names,
         )
 
 
@@ -85,14 +77,11 @@ def test_fail_multivar_treat_efficient_backdoor_algorithms():
         observed_node_names=example["observed_node_names"],
     )
     ident_eff = CausalIdentifier(
-        graph=G,
-        estimand_type="nonparametric-ate",
-        method_name="efficient-mincost-adjustment",
+        graph=G, estimand_type="nonparametric-ate", method_name="efficient-mincost-adjustment",
     )
     with pytest.raises(Exception):
         ident_eff.identify_effect(
-            costs=example["costs"],
-            conditional_node_names=example["conditional_node_names"],
+            costs=example["costs"], conditional_node_names=example["conditional_node_names"],
         )
 
 
@@ -105,12 +94,9 @@ def test_fail_multivar_outcome_efficient_backdoor_algorithms():
         observed_node_names=example["observed_node_names"],
     )
     ident_eff = CausalIdentifier(
-        graph=G,
-        estimand_type="nonparametric-ate",
-        method_name="efficient-mincost-adjustment",
+        graph=G, estimand_type="nonparametric-ate", method_name="efficient-mincost-adjustment",
     )
     with pytest.raises(Exception):
         ident_eff.identify_effect(
-            costs=example["costs"],
-            conditional_node_names=example["conditional_node_names"],
+            costs=example["costs"], conditional_node_names=example["conditional_node_names"],
         )

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -14,9 +14,7 @@ from .base import TestRefuter
 class TestAddUnobservedCommonCauseRefuter(object):
     @mark.parametrize(
         ["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
-        [
-            (0.01, "backdoor.propensity_score_matching", 0.01, 0.02),
-        ],
+        [(0.01, "backdoor.propensity_score_matching", 0.01, 0.02),],
     )
     def test_refutation_binary_treatment(
         self, error_tolerance, estimator_method, effect_strength_on_t, effect_strength_on_y
@@ -34,9 +32,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
 
     @mark.parametrize(
         ["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
-        [
-            (0.01, "iv.instrumental_variable", 0.01, 0.02),
-        ],
+        [(0.01, "iv.instrumental_variable", 0.01, 0.02),],
     )
     def test_refutation_continuous_treatment(
         self, error_tolerance, estimator_method, effect_strength_on_t, effect_strength_on_y
@@ -54,9 +50,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
 
     @mark.parametrize(
         ["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
-        [
-            (0.01, "iv.instrumental_variable", np.arange(0.01, 0.02, 0.001), np.arange(0.02, 0.03, 0.001)),
-        ],
+        [(0.01, "iv.instrumental_variable", np.arange(0.01, 0.02, 0.001), np.arange(0.02, 0.03, 0.001)),],
     )
     @patch("matplotlib.pyplot.figure")
     def test_refutation_continuous_treatment_range_both_treatment_outcome(
@@ -76,9 +70,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
 
     @mark.parametrize(
         ["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
-        [
-            (0.01, "iv.instrumental_variable", np.arange(0.01, 0.02, 0.001), 0.02),
-        ],
+        [(0.01, "iv.instrumental_variable", np.arange(0.01, 0.02, 0.001), 0.02),],
     )
     @patch("matplotlib.pyplot.figure")
     def test_refutation_continuous_treatment_range_treatment(
@@ -98,9 +90,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
 
     @mark.parametrize(
         ["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
-        [
-            (0.01, "iv.instrumental_variable", 0.01, np.arange(0.02, 0.03, 0.001)),
-        ],
+        [(0.01, "iv.instrumental_variable", 0.01, np.arange(0.02, 0.03, 0.001)),],
     )
     @patch("matplotlib.pyplot.figure")
     def test_refutation_continuous_treatment_range_outcome(
@@ -120,9 +110,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
 
     @mark.parametrize(
         ["estimator_method", "effect_strength_on_t", "benchmark_common_causes", "simulated_method_name"],
-        [
-            ("backdoor.linear_regression", [1, 2, 3], ["W3"], "linear-partial-R2"),
-        ],
+        [("backdoor.linear_regression", [1, 2, 3], ["W3"], "linear-partial-R2"),],
     )
     @patch("matplotlib.pyplot.figure")
     def test_linear_sensitivity_with_confounders(
@@ -177,9 +165,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
 
     @mark.parametrize(
         ["estimator_method", "effect_strength_on_t", "benchmark_common_causes", "simulated_method_name"],
-        [
-            ("backdoor.linear_regression", [1, 2, 3], ["W3"], "linear-partial-R2"),
-        ],
+        [("backdoor.linear_regression", [1, 2, 3], ["W3"], "linear-partial-R2"),],
     )
     @patch("matplotlib.pyplot.figure")
     def test_linear_sensitivity_given_strength_of_confounding(
@@ -237,9 +223,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
             "simulated_method_name",
             "rvalue_threshold",
         ],
-        [
-            ("backdoor.linear_regression", [1, 2, 3], ["W3"], "linear-partial-R2", 0.95),
-        ],
+        [("backdoor.linear_regression", [1, 2, 3], ["W3"], "linear-partial-R2", 0.95),],
     )
     @patch("matplotlib.pyplot.figure")
     def test_linear_sensitivity_dataset_without_confounders(

--- a/tests/causal_refuters/test_bootstrap_refuter.py
+++ b/tests/causal_refuters/test_bootstrap_refuter.py
@@ -35,10 +35,7 @@ class TestDataSubsetRefuter(object):
         self, error_tolerance, estimator_method, num_common_causes, required_variables, num_samples
     ):
         refuter_tester = TestRefuter(
-            error_tolerance,
-            estimator_method,
-            "bootstrap_refuter",
-            required_variables=required_variables,
+            error_tolerance, estimator_method, "bootstrap_refuter", required_variables=required_variables,
         )
         refuter_tester.continuous_treatment_testsuite(
             num_samples=num_samples, num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause"

--- a/tests/do_sampler/test_pandas_do_api.py
+++ b/tests/do_sampler/test_pandas_do_api.py
@@ -11,10 +11,7 @@ import dowhy.datasets
 @mark.usefixtures("fixed_seed")
 class TestPandasDoAPI(object):
     @mark.parametrize(
-        ["N", "error_tolerance"],
-        [
-            (10000, 0.1),
-        ],
+        ["N", "error_tolerance"], [(10000, 0.1),],
     )
     def test_pandas_api_discrete_cause_continuous_confounder(self, N, error_tolerance):
         data = dowhy.datasets.linear_dataset(
@@ -53,10 +50,7 @@ class TestPandasDoAPI(object):
         assert res
 
     @mark.parametrize(
-        ["N", "error_tolerance"],
-        [
-            (10000, 0.1),
-        ],
+        ["N", "error_tolerance"], [(10000, 0.1),],
     )
     def test_pandas_api_discrete_cause_discrete_confounder(self, N, error_tolerance):
         data = dowhy.datasets.linear_dataset(
@@ -96,10 +90,7 @@ class TestPandasDoAPI(object):
         assert res
 
     @mark.parametrize(
-        ["N", "error_tolerance"],
-        [
-            (10000, 0.1),
-        ],
+        ["N", "error_tolerance"], [(10000, 0.1),],
     )
     def test_pandas_api_continuous_cause_discrete_confounder(self, N, error_tolerance):
         data = dowhy.datasets.linear_dataset(
@@ -139,10 +130,7 @@ class TestPandasDoAPI(object):
         assert res
 
     @mark.parametrize(
-        ["N", "error_tolerance"],
-        [
-            (10000, 0.1),
-        ],
+        ["N", "error_tolerance"], [(10000, 0.1),],
     )
     def test_pandas_api_continuous_cause_continuous_confounder(self, N, error_tolerance):
         data = dowhy.datasets.linear_dataset(
@@ -188,10 +176,7 @@ class TestPandasDoAPI(object):
     """
 
     @mark.parametrize(
-        ["N", "variable_types"],
-        [
-            (10000, {"v0": "b", "y": "c", "W0": "c"}),
-        ],
+        ["N", "variable_types"], [(10000, {"v0": "b", "y": "c", "W0": "c"}),],
     )
     def test_pandas_api_with_full_specification_of_type(self, N, variable_types):
         data = dowhy.datasets.linear_dataset(
@@ -204,10 +189,7 @@ class TestPandasDoAPI(object):
         assert True
 
     @mark.parametrize(
-        ["N", "variable_types"],
-        [
-            (10000, {"v0": "b", "W0": "c"}),
-        ],
+        ["N", "variable_types"], [(10000, {"v0": "b", "W0": "c"}),],
     )
     def test_pandas_api_with_partial_specification_of_type(self, N, variable_types):
         data = dowhy.datasets.linear_dataset(
@@ -220,10 +202,7 @@ class TestPandasDoAPI(object):
         assert True
 
     @mark.parametrize(
-        ["N", "variable_types"],
-        [
-            (10000, {}),
-        ],
+        ["N", "variable_types"], [(10000, {}),],
     )
     def test_pandas_api_with_no_specification_of_type(self, N, variable_types):
         data = dowhy.datasets.linear_dataset(
@@ -236,10 +215,7 @@ class TestPandasDoAPI(object):
         assert True
 
     @mark.parametrize(
-        ["N", "variable_types"],
-        [
-            (1, {"v0": "b", "W0": "c"}),
-        ],
+        ["N", "variable_types"], [(1, {"v0": "b", "W0": "c"}),],
     )
     def test_pandas_api_with_dummy_data(self, N, variable_types):
         df = pd.DataFrame({"x": [0, 0.5, 1], "y": [1, 0.5, 0], "a": [0, 0.5, 0], "b": [0.25, 0, 0]})

--- a/tests/gcm/test_auto.py
+++ b/tests/gcm/test_auto.py
@@ -19,7 +19,7 @@ def __generate_linear_regression_data():
 
 def __generate_non_linear_regression_data():
     X = np.random.normal(0, 1, (1000, 5))
-    Y = np.sum(X**2, axis=1)
+    Y = np.sum(X ** 2, axis=1)
 
     return X, Y
 

--- a/tests/gcm/test_validation.py
+++ b/tests/gcm/test_validation.py
@@ -17,7 +17,7 @@ from dowhy.gcm import (
 
 def _generate_simple_non_linear_data() -> pd.DataFrame:
     X = np.random.normal(loc=0, scale=1, size=5000)
-    Y = X**2 + np.random.normal(loc=0, scale=1, size=5000)
+    Y = X ** 2 + np.random.normal(loc=0, scale=1, size=5000)
     Z = np.exp(-Y) + np.random.normal(loc=0, scale=1, size=5000)
 
     return pd.DataFrame(data=dict(X=X, Y=Y, Z=Z))

--- a/tests/test_causal_model.py
+++ b/tests/test_causal_model.py
@@ -10,10 +10,7 @@ from dowhy import CausalModel
 
 class TestCausalModel(object):
     @mark.parametrize(
-        ["beta", "num_samples", "num_treatments"],
-        [
-            (10, 100, 1),
-        ],
+        ["beta", "num_samples", "num_treatments"], [(10, 100, 1),],
     )
     def test_external_estimator(self, beta, num_samples, num_treatments):
         num_common_causes = 5
@@ -49,10 +46,7 @@ class TestCausalModel(object):
         assert estimate.estimator.propensity_score_model.max_iter == 1000
 
     @mark.parametrize(
-        ["beta", "num_instruments", "num_samples", "num_treatments"],
-        [
-            (10, 1, 100, 1),
-        ],
+        ["beta", "num_instruments", "num_samples", "num_treatments"], [(10, 1, 100, 1),],
     )
     def test_graph_input(self, beta, num_instruments, num_samples, num_treatments):
         num_common_causes = 5
@@ -91,10 +85,7 @@ class TestCausalModel(object):
         assert all(node_name in common_causes for node_name in ["X1", "X2"])
 
     @mark.parametrize(
-        ["beta", "num_instruments", "num_samples", "num_treatments"],
-        [
-            (10, 1, 100, 1),
-        ],
+        ["beta", "num_instruments", "num_samples", "num_treatments"], [(10, 1, 100, 1),],
     )
     def test_graph_input2(self, beta, num_instruments, num_samples, num_treatments):
         num_common_causes = 5
@@ -201,10 +192,7 @@ class TestCausalModel(object):
         assert all(node_name in common_causes for node_name in ["X1", "X2"])
 
     @mark.parametrize(
-        ["beta", "num_instruments", "num_samples", "num_treatments"],
-        [
-            (10, 1, 100, 1),
-        ],
+        ["beta", "num_instruments", "num_samples", "num_treatments"], [(10, 1, 100, 1),],
     )
     def test_graph_input3(self, beta, num_instruments, num_samples, num_treatments):
         num_common_causes = 5
@@ -265,10 +253,7 @@ class TestCausalModel(object):
         assert "Unobserved Confounders" not in all_nodes
 
     @mark.parametrize(
-        ["beta", "num_instruments", "num_samples", "num_treatments"],
-        [
-            (10, 1, 100, 1),
-        ],
+        ["beta", "num_instruments", "num_samples", "num_treatments"], [(10, 1, 100, 1),],
     )
     def test_graph_input4(self, beta, num_instruments, num_samples, num_treatments):
         num_common_causes = 5
@@ -311,19 +296,13 @@ class TestCausalModel(object):
         assert "Unobserved Confounders" not in all_nodes
 
     @mark.parametrize(
-        ["num_variables", "num_samples"],
-        [
-            (10, 5000),
-        ],
+        ["num_variables", "num_samples"], [(10, 5000),],
     )
     def test_graph_refutation(self, num_variables, num_samples):
         data = dowhy.datasets.dataset_from_random_graph(num_vars=num_variables, num_samples=num_samples)
         df = data["df"]
         model = CausalModel(
-            data=df,
-            treatment=data["treatment_name"],
-            outcome=data["outcome_name"],
-            graph=data["gml_graph"],
+            data=df, treatment=data["treatment_name"], outcome=data["outcome_name"], graph=data["gml_graph"],
         )
         graph_refutation_object = model.refute_graph(
             k=1,
@@ -335,10 +314,7 @@ class TestCausalModel(object):
         assert graph_refutation_object.refutation_result == True
 
     @mark.parametrize(
-        ["num_variables", "num_samples"],
-        [
-            (10, 5000),
-        ],
+        ["num_variables", "num_samples"], [(10, 5000),],
     )
     def test_graph_refutation2(self, num_variables, num_samples):
         data = dowhy.datasets.dataset_from_random_graph(num_vars=num_variables, num_samples=num_samples)
@@ -420,12 +396,7 @@ class TestCausalModel(object):
         ]
         ]
         """
-        model = CausalModel(
-            data=df,
-            treatment=data["treatment_name"],
-            outcome=data["outcome_name"],
-            graph=gml_str,
-        )
+        model = CausalModel(data=df, treatment=data["treatment_name"], outcome=data["outcome_name"], graph=gml_str,)
         graph_refutation_object = model.refute_graph(
             k=2,
             independence_test={


### PR DESCRIPTION
Hi team, this PR mainly exposes the max_backdoor_iterations parameter to the user.
Made necessary changes to causal_model.py and causal_identifier.py files.

Why we need to parameterize max_backdoor_iterations?
Currently, max_backdoor_iterations, which now would be one of a parameter in identify_effect method is a private variable in CausalIdentifier.py file.
Defaulted to a static value of 100000, it makes sure to perform up till 100000 networkx.d_seperated operations un till a valid adjustment set of co-variates are found.
https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.d_separation.d_separated.html
For a one-time activity of looping - 100K could be fine, but generally if we have a large causal graph, we don't just end up in estimating only one variables effect in other variable. We would perform many trails by back-and-forth selecting many variables as treatments and outcomes.

For each of these trails, because of statically coded 100K max_backdoor_iterations, we would perform 100k networkx.d_seperated tests.
Due to this reason, we would like to parameterize max_backdoor_iterations, such that an end-user now can retrieve results faster with regulation on number of backdoor_iterations.

Code changes and Logic:
causal_model.py ->
Added max_backdoor_iterations as one of a parameter to the identify_effect method and defaulted a value of 100000.
copied max_backdoor_iterations variable and added as one of a parameter into CausalIdentifier method call.

causal_identifier.py ->
Removed previous hardcoded private variable: MAX_BACKDOOR_ITERATIONS
Added max_backdoor_iterations as one of a parameter to the CausalIdentifier method and initialized it to a self object.
changed everywhere in file's code from MAX_BACKDOOR_ITERATIONS to self.max_backdoor_iterations
Implemented a logic to check on every iteration, whether #number_of_iterations is greater than max_backdoor_iterations. If yes - breaks from the loop, else - continues.

New enhancement but with previous code Logic:
Step-0: max_backdoor_iterations=25000
Step-1: nx.d_seperated method stopped executing 320000th time.
Step-2: if 320000>10000
Step-3: breaks from the loop
(why d_seperated logic should execute many combinations whilst user request only for 25K times)
Note: 320000 is a number, which I've observed from the itertools.combination() method

New enhancement with newest code Logic:
Step-0: max_backdoor_iterations=25000
Step-1: Check #no_iter>max_iter for every inner loop-thru
Step-2: nx.d_seperated method getting stopped at 25000th time.
Step-3: if 25000>25000
Step-4: breaks from the loop

Please let me know in case of any questions.
Chaitanya Molabanti