### PR TITLE
Remove dowhy_causal_discovery_example from tests

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -16,7 +16,9 @@ advanced_notebooks = [
     "dowhy_lalonde_example.ipynb",
     "lalonde_pandas_api.ipynb",
     # requires Rpy2 for causal discovery
-    "dowhy_causal_discovery_example.ipynb",
+    # daily tests of dowhy_causal_discovery_example.ipynb are failing due to cdt/rpy2 config.  
+    # comment out, since we are switching causal discovery implementations
+    # "dowhy_causal_discovery_example.ipynb",
     # will be removed
     "dowhy_optimize_backdoor_example.ipynb",
     # applied notebook, not necessary to test each time

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -16,7 +16,7 @@ advanced_notebooks = [
     "dowhy_lalonde_example.ipynb",
     "lalonde_pandas_api.ipynb",
     # requires Rpy2 for causal discovery
-    # daily tests of dowhy_causal_discovery_example.ipynb are failing due to cdt/rpy2 config.  
+    # daily tests of dowhy_causal_discovery_example.ipynb are failing due to cdt/rpy2 config.
     # comment out, since we are switching causal discovery implementations
     # "dowhy_causal_discovery_example.ipynb",
     # will be removed

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -15,10 +15,6 @@ advanced_notebooks = [
     "dowhy_refutation_testing.ipynb",
     "dowhy_lalonde_example.ipynb",
     "lalonde_pandas_api.ipynb",
-    # requires Rpy2 for causal discovery
-    # daily tests of dowhy_causal_discovery_example.ipynb are failing due to cdt/rpy2 config.
-    # comment out, since we are switching causal discovery implementations
-    # "dowhy_causal_discovery_example.ipynb",
     # will be removed
     "dowhy_optimize_backdoor_example.ipynb",
     # applied notebook, not necessary to test each time
@@ -35,6 +31,13 @@ advanced_notebooks = [
     "gcm_supply_chain_dist_change.ipynb",
     "dowhy_simple_example.ipynb",
     "gcm_401k_analysis.ipynb",
+]
+
+ignore_notebooks = [
+    # requires Rpy2 for causal discovery
+    # daily tests of dowhy_causal_discovery_example.ipynb are failing due to cdt/rpy2 config.
+    # comment out, since we are switching causal discovery implementations
+    "dowhy_causal_discovery_example.ipynb"
 ]
 
 # Adding the dowhy root folder to the python path so that jupyter notebooks
@@ -88,7 +91,9 @@ def test_confounder_notebook():
 """
 parameter_list = []
 for nb in notebooks_list:
-    if nb in advanced_notebooks:
+    if nb in ignore_notebooks:
+        continue
+    elif nb in advanced_notebooks:
         param = pytest.param(nb, marks=[mark.advanced, mark.notebook], id=nb)
     else:
         param = pytest.param(nb, marks=[mark.notebook], id=nb)


### PR DESCRIPTION
Remove dowhy_causal_discovery_example.ipynb from advanced tests that are run daily.  It is failing due to a cdt install problem.  Temporarily disabling since we are switching CD implementations.

Signed-off-by: emrekiciman <emrek@microsoft.com>