### PR TITLE
Fix syntax error in dowhy_ranking_methods notebook

### DIFF
--- a/docs/source/example_notebooks/dowhy_ranking_methods.ipynb
+++ b/docs/source/example_notebooks/dowhy_ranking_methods.ipynb
@@ -765,7 +765,7 @@
   },
   "nbsphinx": {
    "execute": "never"
-  },
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4


### PR DESCRIPTION
This fixes failures like this one: https://github.com/py-why/dowhy/actions/runs/3301256767/jobs/5446526501#step:7:133