### PR TITLE
fix placebo treatment refuter randint call

### DIFF
--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -134,7 +134,7 @@ def _refute_once(
                 )
             )
             new_treatment = np.random.randint(
-                low=data[treatment_names[0]].min(), high=data[treatment_names[0]].max(), size=data.shape[0]
+                low=data[treatment_names[0]].min(), high=data[treatment_names[0]].max() + 1, size=data.shape[0]
             )
 
         elif "category" in type_dict[treatment_names[0]].name:


### PR DESCRIPTION
Fix for bug reported in issue #699 

According to numpy docs: https://numpy.org/doc/stable/reference/random/generated/numpy.random.randint.html the `high` parameter is exclusive, meaning the highest value is never used in the `new_treatment` (in binary treatments it means this generates only 0's). Adding `+1` should resolve this. 


Signed-off-by: Andres Morales <andresmor@microsoft.com>