### PR TITLE
Adding ProductRegressor to gcm auto assignment

### DIFF
--- a/dowhy/gcm/ml/regression.py
+++ b/dowhy/gcm/ml/regression.py
@@ -115,6 +115,10 @@ def create_ada_boost_regressor(**kwargs) -> SklearnRegressionModel:
     return SklearnRegressionModel(AdaBoostRegressor(**kwargs))
 
 
+def create_product_regressor() -> PredictionModel:
+    return ProductRegressor()
+
+
 class InvertibleIdentityFunction(InvertibleFunction):
     def evaluate(self, X: np.ndarray) -> np.ndarray:
         return X
@@ -137,3 +141,15 @@ class InvertibleLogarithmicFunction(InvertibleFunction):
 
     def evaluate_inverse(self, X: np.ndarray) -> np.ndarray:
         return np.exp(X)
+
+
+class ProductRegressor(PredictionModel):
+    def fit(self, X, Y):
+        # Nothing to fit here.
+        pass
+
+    def predict(self, X):
+        return np.prod(X, axis=1).reshape(-1, 1)
+
+    def clone(self):
+        return ProductRegressor()

--- a/tests/gcm/ml/test_regression.py
+++ b/tests/gcm/ml/test_regression.py
@@ -1,0 +1,12 @@
+import numpy as np
+from _pytest.python_api import approx
+
+from dowhy.gcm.ml.regression import create_product_regressor
+
+
+def test_given_product_regressor_then_computes_correct_values():
+    X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+    mdl = create_product_regressor()
+
+    assert mdl.predict(X).reshape(-1) == approx(np.array([6, 120, 504]))


### PR DESCRIPTION
Adding ProductRegressor to gcm auto assignment
    
This model simply takes the product of the inputs.

Signed-off-by: Patrick Bloebaum <bloebp@amazon.com>