### PR TITLE
Replace HSCI and KCI with causal-learn package functions

### DIFF
--- a/dowhy/gcm/independence_test/__init__.py
+++ b/dowhy/gcm/independence_test/__init__.py
@@ -10,6 +10,7 @@ def independence_test(X, Y, conditioned_on=None, method="kernel"):
 
       * K. Zhang, J. Peters, D. Janzing, B. Schölkopf. *Kernel-based Conditional Independence Test and Application in Causal Discovery*. UAI'11, Pages 804–813, 2011.
       * A. Gretton, K. Fukumizu, C.-H. Teo, L. Song, B. Schölkopf, A. Smola. *A Kernel Statistical Test of Independence*. NIPS 21, 2007.
+      Here, we utilize the implementations of the https://github.com/cmu-phil/causal-learn package.
 
     * `approx_kernel`: Approximate kernel-based (conditional) independence test.
 

--- a/dowhy/gcm/independence_test/kernel_operation.py
+++ b/dowhy/gcm/independence_test/kernel_operation.py
@@ -2,13 +2,13 @@
 future.
 """
 
-from typing import Callable, List, Optional
+from typing import Optional
 
 import numpy as np
 from sklearn.kernel_approximation import Nystroem
 from sklearn.metrics import euclidean_distances
 
-from dowhy.gcm.util.general import is_categorical, shape_into_2d
+from dowhy.gcm.util.general import shape_into_2d
 
 
 def apply_rbf_kernel(X: np.ndarray, precision: Optional[float] = None) -> np.ndarray:
@@ -96,32 +96,6 @@ def approximate_delta_kernel_features(X: np.ndarray, num_random_components: int)
     result[result != 0] = 1
 
     return result
-
-
-def auto_create_list_of_kernels(X: np.ndarray) -> List[Callable[[np.ndarray], np.ndarray]]:
-    X = shape_into_2d(X)
-
-    tmp_list = []
-    for i in range(X.shape[1]):
-        if not is_categorical(X[:, i]):
-            tmp_list.append(apply_rbf_kernel)
-        else:
-            tmp_list.append(apply_delta_kernel)
-
-    return tmp_list
-
-
-def auto_create_list_of_kernel_approximations(X: np.ndarray) -> List[Callable[[np.ndarray, int], np.ndarray]]:
-    X = shape_into_2d(X)
-
-    tmp_list = []
-    for i in range(X.shape[1]):
-        if not is_categorical(X[:, i]):
-            tmp_list.append(approximate_rbf_kernel_features)
-        else:
-            tmp_list.append(approximate_delta_kernel_features)
-
-    return tmp_list
 
 
 def _median_based_precision(distances: np.ndarray) -> float:

--- a/tests/gcm/independence_test/test_kernel.py
+++ b/tests/gcm/independence_test/test_kernel.py
@@ -2,11 +2,9 @@ import random
 
 import numpy as np
 import pytest
-from _pytest.python_api import approx
 from flaky import flaky
 
 from dowhy.gcm.independence_test import approx_kernel_based, kernel_based
-from dowhy.gcm.independence_test.kernel import _fast_centering
 
 
 @flaky(max_runs=5)
@@ -60,11 +58,6 @@ def test_given_random_seed_when_perform_conditional_kernel_based_test_then_retur
     result_2 = kernel_based(x, z, y, bootstrap_num_samples_per_run=5, bootstrap_num_runs=2, p_value_adjust_func=np.mean)
 
     assert result_1 == result_2
-
-
-def test_given_too_few_samples_when_perform_kernel_based_test_then_raise_error():
-    with pytest.raises(RuntimeError):
-        kernel_based(np.array([1, 2, 3, 4]), np.array([1, 3, 2, 4]))
 
 
 @flaky(max_runs=5)
@@ -312,14 +305,6 @@ def test_given_random_seed_when_perform_pairwise_approx_kernel_based_test_then_r
     )
 
     assert result_1 == result_2
-
-
-def test_when_using_fast_centering_then_gives_expected_results():
-    X = np.random.normal(0, 1, (100, 100))
-
-    h = np.identity(X.shape[0]) - np.ones((X.shape[0], X.shape[0]), dtype=float) / X.shape[0]
-
-    assert _fast_centering(X) == approx(h @ X @ h)
 
 
 @flaky(max_runs=3)


### PR DESCRIPTION
The causal-learn package provides more sophisticated implementations of the kernel independence tests. Instead of reimplementing it, we utilize the existing functions from causal-learn instead.

Signed-off-by: Patrick Bloebaum <bloebp@amazon.com>