### PR TITLE
Add pytest markers for "focused" and "notebook"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,11 @@ sphinx-copybutton = "0.5.0"
 nbconvert = { version = "7.0.0rc3", allow-prereleases = true }
 
 [tool.pytest.ini_options]
-markers = ["advanced: not be to run each time. only on package updates."]
+markers = [
+    "advanced: not be to run each time. only on package updates.",
+    "notebook: jupyter notebook tests",
+    "focused: a debug marker to focus on specific tests"
+]
 
 [tool.poe.tasks]
 # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
By declaring these markers ahead-of-time we avoid some warnings during test runs.

Signed-off-by: Chris Trevino <darthtrevino@gmail.com>