### PR TITLE
Make unit test on intervention less strict

### DIFF
--- a/tests/gcm/test_whatif.py
+++ b/tests/gcm/test_whatif.py
@@ -63,8 +63,8 @@ def test_interventional_samples_conditional():
     sample = sample.squeeze()
     assert sample[0] == 0
     assert sample[1] == 1
-    assert sample[2] == approx(10, abs=0.2)
-    assert sample[3] == approx(5, abs=0.2)
+    assert sample[2] == approx(10, abs=0.5)
+    assert sample[3] == approx(5, abs=0.25)
 
 
 @flaky(max_runs=3)


### PR DESCRIPTION
To avoid flaky tests.

This failed here: https://github.com/py-why/dowhy/actions/runs/3343835339/jobs/5537478998#step:9:196