### PR TITLE
Run docs generation on correct version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,14 @@ on:
     workflows: [ "Build Docker image (docs)" ]
     types:
       - completed
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**/*'
+      - 'dowhy/**/*'
+      - pyproject.toml
+      - poetry.lock
+      - .github/workflows/docs.yml
 
 jobs:
   docs:

--- a/docs/generate_docs.sh
+++ b/docs/generate_docs.sh
@@ -8,6 +8,7 @@ mv source/conf.py source/conf.py.orig
 cp source/conf-rtd.py source/conf.py
 cp source/_templates/versions-rtd.html source/_templates/versions.html
 
+poetry run pip uninstall -y dowhy
 poetry run sphinx-multiversion --dump-metadata source ${OUTPUT_DIR}
 poetry run sphinx-multiversion source ${OUTPUT_DIR}
 


### PR DESCRIPTION
This PR uninstalls the latest dowhy version when generating docs. This is necessary to avoid that example notebooks from older versions (built for older documentation versions) run against latest version of DoWhy and break.

This PR includes changes from https://github.com/py-why/dowhy/pull/741 to generate the docs already in this PR.