### PR TITLE
Basic support for multivalue categorical treatments

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -3,10 +3,9 @@ from collections import namedtuple
 from typing import Dict, List, Optional, Union
 
 import numpy as np
-from numpy.distutils.misc_util import is_sequence
-
 import pandas as pd
 import sympy as sp
+from numpy.distutils.misc_util import is_sequence
 from sklearn.utils import resample
 
 import dowhy.interpreters as interpreters
@@ -226,34 +225,6 @@ class CausalEstimator:
         df_notreatment = self._data.loc[self._data[self._treatment_name] == 0]
         est = np.mean(df_withtreatment[self._outcome_name]) - np.mean(df_notreatment[self._outcome_name])
         return CausalEstimate(est, None, None, control_value=0, treatment_value=1)
-
-    def effect_tt(self, df: pd.DataFrame, *args, **kwargs):
-        """
-        Effect of treatment on the treated
-        @param df: unit features and treatment values
-        @param args: passed through to effect estimator
-        @param kwargs: passed through to effect estimator
-        @return: np.array of len(df) with effects of the actual treatment applied
-        """
-
-        eff = self.effect(df, *args, **kwargs).reshape((len(df), len(self._treatment_value)))
-
-        out = np.zeros(len(df))
-        if is_sequence(self._treatment_value) and not isinstance(self._treatment_value, str):
-            treatment_value = self._treatment_value
-        else:
-            treatment_value = [self._treatment_value]
-
-        if is_sequence(self._treatment_name) and not isinstance(self._treatment_name, str):
-            treatment_name = self._treatment_name[0]
-        else:
-            treatment_name = self._treatment_name
-
-        eff = np.reshape(eff, (len(df), len(treatment_value)))
-
-        for c, col in enumerate(treatment_value):
-            out[df[treatment_name] == col] = eff[df[treatment_name] == col, c]
-        return pd.Series(data=out, index=df.index)
 
     def _estimate_effect_fn(self, data_df):
         """Function used in conditional effect estimation. This function is to be overridden by each child estimator.

--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -28,28 +28,20 @@ class Econml(CausalEstimator):
         """
         # Required to ensure that self.method_params contains all the
         # parameters to create an object of this class
-        args_dict = {
-            k: v for k, v in locals().items() if k not in type(self)._STD_INIT_ARGS
-        }
+        args_dict = {k: v for k, v in locals().items() if k not in type(self)._STD_INIT_ARGS}
         args_dict.update(kwargs)
         super().__init__(*args, **args_dict)
         self._econml_methodname = econml_methodname
         self.logger.info("INFO: Using EconML Estimator")
         self.identifier_method = self._target_estimand.identifier_method
-        self._observed_common_causes_names = (
-            self._target_estimand.get_backdoor_variables().copy()
-        )
+        self._observed_common_causes_names = self._target_estimand.get_backdoor_variables().copy()
         # For metalearners only--issue a warning if w contains variables not in x
         (module_name, _, class_name) = self._econml_methodname.rpartition(".")
         if module_name.endswith("metalearners"):
             effect_modifier_names = []
             if self._effect_modifier_names is not None:
                 effect_modifier_names = self._effect_modifier_names.copy()
-            w_diff_x = [
-                w
-                for w in self._observed_common_causes_names
-                if w not in effect_modifier_names
-            ]
+            w_diff_x = [w for w in self._observed_common_causes_names if w not in effect_modifier_names]
             if len(w_diff_x) > 0:
                 self.logger.warn(
                     "Concatenating common_causes and effect_modifiers and providing a single list of variables to metalearner estimator method, "
@@ -61,42 +53,28 @@ class Econml(CausalEstimator):
                 # Also only update self._effect_modifiers, and create a copy of self._effect_modifier_names
                 # the latter can be used by other estimator methods later
                 self._effect_modifiers = self._data[effect_modifier_names]
-                self._effect_modifiers = pd.get_dummies(
-                    self._effect_modifiers, drop_first=True
-                )
+                self._effect_modifiers = pd.get_dummies(self._effect_modifiers, drop_first=True)
                 self._effect_modifier_names = effect_modifier_names
             self.logger.debug("Effect modifiers: " + ",".join(effect_modifier_names))
         if self._observed_common_causes_names:
-            self._observed_common_causes = self._data[
-                self._observed_common_causes_names
-            ]
-            self._observed_common_causes = pd.get_dummies(
-                self._observed_common_causes, drop_first=True
-            )
+            self._observed_common_causes = self._data[self._observed_common_causes_names]
+            self._observed_common_causes = pd.get_dummies(self._observed_common_causes, drop_first=True)
         else:
             self._observed_common_causes = None
-        self.logger.debug(
-            "Back-door variables used:" + ",".join(self._observed_common_causes_names)
-        )
+        self.logger.debug("Back-door variables used:" + ",".join(self._observed_common_causes_names))
         # Instrumental variables names, if present
         # choosing the instrumental variable to use
         if getattr(self, "iv_instrument_name", None) is None:
-            self.estimating_instrument_names = (
-                self._target_estimand.instrumental_variables
-            )
+            self.estimating_instrument_names = self._target_estimand.instrumental_variables
         else:
             self.estimating_instrument_names = parse_state(self.iv_instrument_name)
         if self.estimating_instrument_names:
             self._estimating_instruments = self._data[self.estimating_instrument_names]
-            self._estimating_instruments = pd.get_dummies(
-                self._estimating_instruments, drop_first=True
-            )
+            self._estimating_instruments = pd.get_dummies(self._estimating_instruments, drop_first=True)
         else:
             self._estimating_instruments = None
         self.estimator = None
-        self.symbolic_estimator = self.construct_symbolic_estimator(
-            self._target_estimand
-        )
+        self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
         self.logger.info(self.symbolic_estimator)
 
     def _get_econml_class_object(self, module_method_name, *args, **kwargs):
@@ -133,20 +111,14 @@ class Econml(CausalEstimator):
             estimator_class = self._get_econml_class_object(self._econml_methodname)
             self.estimator = estimator_class(**self.method_params["init_params"])
             # Calling the econml estimator's fit method
-            estimator_argspec = inspect.getfullargspec(
-                inspect.unwrap(self.estimator.fit)
-            )
+            estimator_argspec = inspect.getfullargspec(inspect.unwrap(self.estimator.fit))
             # As of v0.9, econml has some kewyord only arguments
             estimator_named_args = estimator_argspec.args + estimator_argspec.kwonlyargs
             estimator_data_args = {
-                arg: named_data_args[arg]
-                for arg in named_data_args.keys()
-                if arg in estimator_named_args
+                arg: named_data_args[arg] for arg in named_data_args.keys() if arg in estimator_named_args
             }
             if self.method_params["fit_params"] is not False:
-                self.estimator.fit(
-                    **estimator_data_args, **self.method_params["fit_params"]
-                )
+                self.estimator.fit(**estimator_data_args, **self.method_params["fit_params"])
 
         X_test = X
         if X is not None:
@@ -205,9 +177,7 @@ class Econml(CausalEstimator):
         return expr
 
     def shap_values(self, df: pd.DataFrame, *args, **kwargs):
-        return self.estimator.shap_values(
-            df[self._effect_modifier_names].values, *args, **kwargs
-        )
+        return self.estimator.shap_values(df[self._effect_modifier_names].values, *args, **kwargs)
 
     def apply_multitreatment(self, df: pd.DataFrame, fun: Callable, *args, **kwargs):
         ests = []
@@ -229,9 +199,7 @@ class Econml(CausalEstimator):
 
     def effect(self, df: pd.DataFrame, *args, **kwargs) -> np.ndarray:
         def effect_fun(df, T0, T1, *args, **kwargs):
-            return self.estimator.effect(
-                df[self._effect_modifier_names].values, T0=T0, T1=T1, *args, **kwargs
-            )
+            return self.estimator.effect(df[self._effect_modifier_names].values, T0=T0, T1=T1, *args, **kwargs)
 
         return self.apply_multitreatment(df, effect_fun, *args, **kwargs)
 
@@ -264,21 +232,15 @@ class Econml(CausalEstimator):
         :param kwargs: passed through to estimator.effect()
         """
 
-        eff = self.effect(df, *args, **kwargs).reshape(
-            (len(df), len(self._treatment_value))
-        )
+        eff = self.effect(df, *args, **kwargs).reshape((len(df), len(self._treatment_value)))
 
         out = np.zeros(len(df))
-        if is_sequence(self._treatment_value) and not isinstance(
-            self._treatment_value, str
-        ):
+        if is_sequence(self._treatment_value) and not isinstance(self._treatment_value, str):
             treatment_value = self._treatment_value
         else:
             treatment_value = [self._treatment_value]
 
-        if is_sequence(self._treatment_name) and not isinstance(
-            self._treatment_name, str
-        ):
+        if is_sequence(self._treatment_name) and not isinstance(self._treatment_name, str):
             treatment_name = self._treatment_name[0]
         else:
             treatment_name = self._treatment_name

--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -3,8 +3,8 @@ from importlib import import_module
 from typing import Callable
 
 import numpy as np
-from numpy.distutils.misc_util import is_sequence
 import pandas as pd
+from numpy.distutils.misc_util import is_sequence
 
 from dowhy.causal_estimator import CausalEstimate, CausalEstimator
 from dowhy.utils.api import parse_state

--- a/dowhy/utils/api.py
+++ b/dowhy/utils/api.py
@@ -1,5 +1,5 @@
 def parse_state(state):
-    if type(state) == str:
+    if type(state) in [str, int]:
         return [state]
     if type(state) == list:
         return state

--- a/tests/causal_estimators/test_econml_estimator.py
+++ b/tests/causal_estimators/test_econml_estimator.py
@@ -81,20 +81,14 @@ class TestEconMLEstimator:
             effect_modifiers=data["effect_modifier_names"],
             graph=data_binary["gml_graph"],
         )
-        identified_estimand_binary = model_binary.identify_effect(
-            proceed_when_unidentifiable=True
-        )
+        identified_estimand_binary = model_binary.identify_effect(proceed_when_unidentifiable=True)
         drlearner_estimate = model_binary.estimate_effect(
             identified_estimand_binary,
             method_name="backdoor.econml.drlearner.LinearDRLearner",
             target_units=lambda df: df["X0"] > 1,
             confidence_intervals=False,
             method_params={
-                "init_params": {
-                    "model_propensity": LogisticRegressionCV(
-                        cv=3, solver="lbfgs", multi_class="auto"
-                    )
-                },
+                "init_params": {"model_propensity": LogisticRegressionCV(cv=3, solver="lbfgs", multi_class="auto")},
                 "fit_params": {},
             },
         )
@@ -126,9 +120,7 @@ class TestEconMLEstimator:
         dims_tx = len(model._treatment) + len(model._effect_modifiers)
         treatment_model = keras.Sequential(
             [
-                keras.layers.Dense(
-                    128, activation="relu", input_shape=(dims_zx,)
-                ),  # sum of dims of Z and X
+                keras.layers.Dense(128, activation="relu", input_shape=(dims_zx,)),  # sum of dims of Z and X
                 keras.layers.Dropout(0.17),
                 keras.layers.Dense(64, activation="relu"),
                 keras.layers.Dropout(0.17),
@@ -138,9 +130,7 @@ class TestEconMLEstimator:
         )
         response_model = keras.Sequential(
             [
-                keras.layers.Dense(
-                    128, activation="relu", input_shape=(dims_tx,)
-                ),  # sum of dims of T and X
+                keras.layers.Dense(128, activation="relu", input_shape=(dims_tx,)),  # sum of dims of T and X
                 keras.layers.Dropout(0.17),
                 keras.layers.Dense(64, activation="relu"),
                 keras.layers.Dropout(0.17),
@@ -226,9 +216,7 @@ class TestEconMLEstimator:
             common_causes="W",
             effect_modifiers="X",
         )
-        identified_estimand = causal_model.identify_effect(
-            proceed_when_unidentifiable=True
-        )
+        identified_estimand = causal_model.identify_effect(proceed_when_unidentifiable=True)
 
         est_2 = causal_model.estimate_effect(
             identified_estimand,
@@ -245,7 +233,5 @@ class TestEconMLEstimator:
 
         est_test = est_2.estimator.effect_tt(test_data)
 
-        est_error = (
-            (est_test - test_data["T"].apply(lambda x: impact[x]).values).abs().max()
-        )
+        est_error = (est_test - test_data["T"].apply(lambda x: impact[x]).values).abs().max()
         assert est_error < 0.01

--- a/tests/causal_estimators/test_econml_estimator.py
+++ b/tests/causal_estimators/test_econml_estimator.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 
 import numpy as np
 import pandas as pd
@@ -8,6 +9,7 @@ from sklearn.linear_model import LogisticRegression, LogisticRegressionCV
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import PolynomialFeatures
 
+import dowhy
 from dowhy import CausalModel, datasets
 
 econml = pytest.importorskip("econml")
@@ -207,7 +209,6 @@ class TestEconMLEstimator:
         df["Y"] = df["W"] + df["T"].apply(lambda x: impact[x])
 
         train_data, test_data = train_test_split(df, train_size=0.9)
-        X_test = test_data[["X", "T"]]
 
         causal_model = CausalModel(
             data=train_data,
@@ -235,3 +236,54 @@ class TestEconMLEstimator:
 
         est_error = (est_test - test_data["T"].apply(lambda x: impact[x]).values).abs().max()
         assert est_error < 0.01
+
+    def test_empty_effect_modifiers(self):
+        np.random.seed(101)
+        data = dowhy.datasets.partially_linear_dataset(
+            beta=10,
+            num_common_causes=7,
+            num_unobserved_common_causes=1,
+            strength_unobserved_confounding=10,
+            num_samples=1000,
+            num_treatments=1,
+            stddev_treatment_noise=10,
+            stddev_outcome_noise=5,
+        )
+
+        # Observed data
+        dropped_cols = ["W0"]
+        user_data = data["df"].drop(dropped_cols, axis=1)
+        # assumed graph
+        user_graph = data["gml_graph"]
+        for col in dropped_cols:
+            user_graph = user_graph.replace('node[ id "{0}" label "{0}"]'.format(col), "")
+            user_graph = re.sub('edge\[ source "{}" target "[vy][0]*"\]'.format(col), "", user_graph)
+
+        model = CausalModel(
+            data=user_data,
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            graph=user_graph,
+            test_significance=None,
+        )
+
+        model._graph.get_effect_modifiers(model._treatment, model._outcome)
+
+        # Identify effect
+        identified_estimand = model.identify_effect(proceed_when_unidentifiable=True)
+
+        # Estimate effect
+        model.estimate_effect(
+            identified_estimand,
+            method_name="backdoor.econml.dml.LinearDML",
+            method_params={
+                "init_params": {
+                    "model_y": GradientBoostingRegressor(),
+                    "model_t": GradientBoostingRegressor(),
+                    "linear_first_stages": False,
+                },
+                "fit_params": {
+                    "cache_values": True,
+                },
+            },
+        )

--- a/tests/causal_estimators/test_econml_estimator.py
+++ b/tests/causal_estimators/test_econml_estimator.py
@@ -197,7 +197,7 @@ class TestEconMLEstimator:
         )
 
     def test_multivalue_treatment(self):
-        n_points = 10000
+        n_points = 100000
         impact = {0: 0.0, 1: 2.0, 2: 1.0}
         df = pd.DataFrame(
             {
@@ -235,7 +235,7 @@ class TestEconMLEstimator:
         est_test = est_2.estimator.effect_tt(test_data)
 
         est_error = (est_test - test_data["T"].apply(lambda x: impact[x]).values).abs().max()
-        assert est_error < 0.01
+        assert est_error < 0.03
 
     def test_empty_effect_modifiers(self):
         np.random.seed(101)

--- a/tests/causal_estimators/test_econml_estimator.py
+++ b/tests/causal_estimators/test_econml_estimator.py
@@ -81,14 +81,20 @@ class TestEconMLEstimator:
             effect_modifiers=data["effect_modifier_names"],
             graph=data_binary["gml_graph"],
         )
-        identified_estimand_binary = model_binary.identify_effect(proceed_when_unidentifiable=True)
+        identified_estimand_binary = model_binary.identify_effect(
+            proceed_when_unidentifiable=True
+        )
         drlearner_estimate = model_binary.estimate_effect(
             identified_estimand_binary,
             method_name="backdoor.econml.drlearner.LinearDRLearner",
             target_units=lambda df: df["X0"] > 1,
             confidence_intervals=False,
             method_params={
-                "init_params": {"model_propensity": LogisticRegressionCV(cv=3, solver="lbfgs", multi_class="auto")},
+                "init_params": {
+                    "model_propensity": LogisticRegressionCV(
+                        cv=3, solver="lbfgs", multi_class="auto"
+                    )
+                },
                 "fit_params": {},
             },
         )
@@ -120,7 +126,9 @@ class TestEconMLEstimator:
         dims_tx = len(model._treatment) + len(model._effect_modifiers)
         treatment_model = keras.Sequential(
             [
-                keras.layers.Dense(128, activation="relu", input_shape=(dims_zx,)),  # sum of dims of Z and X
+                keras.layers.Dense(
+                    128, activation="relu", input_shape=(dims_zx,)
+                ),  # sum of dims of Z and X
                 keras.layers.Dropout(0.17),
                 keras.layers.Dense(64, activation="relu"),
                 keras.layers.Dropout(0.17),
@@ -130,7 +138,9 @@ class TestEconMLEstimator:
         )
         response_model = keras.Sequential(
             [
-                keras.layers.Dense(128, activation="relu", input_shape=(dims_tx,)),  # sum of dims of T and X
+                keras.layers.Dense(
+                    128, activation="relu", input_shape=(dims_tx,)
+                ),  # sum of dims of T and X
                 keras.layers.Dropout(0.17),
                 keras.layers.Dense(64, activation="relu"),
                 keras.layers.Dropout(0.17),
@@ -194,7 +204,6 @@ class TestEconMLEstimator:
             },
         )
 
-
     def test_multivalue_treatment(self):
         n_points = 10000
         impact = {0: 0.0, 1: 2.0, 2: 1.0}
@@ -208,7 +217,7 @@ class TestEconMLEstimator:
         df["Y"] = df["W"] + df["T"].apply(lambda x: impact[x])
 
         train_data, test_data = train_test_split(df, train_size=0.9)
-        X_test = test_data[["X","T"]]
+        X_test = test_data[["X", "T"]]
 
         causal_model = CausalModel(
             data=train_data,
@@ -236,10 +245,7 @@ class TestEconMLEstimator:
 
         est_test = est_2.estimator.effect_tt(test_data)
 
-        est_error = (est_test - test_data["T"].apply(lambda x: impact[x]).values).abs().max()
+        est_error = (
+            (est_test - test_data["T"].apply(lambda x: impact[x]).values).abs().max()
+        )
         assert est_error < 0.01
-
-
-
-
-


### PR DESCRIPTION
Support multivalue categorical treatments in econml.py; add a utility method to CausalEstimator that returns the effect of the treatment that was actually used, and works with the multivalue changes