### PR TITLE
Restore Version Selector into Build

### DIFF
--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,24 +1,20 @@
 <div class="dropdown" id="version_switcher">
     <button type="button" class="btn btn-sm navbar-btn dropdown-toggle" id="version_switcher_button" data-toggle="dropdown">
-        {{ current_version.name if current_version.name != "main" else "main-branch" }}
+        {{ current_version.name  }}
         <span class="caret"></span>
     </button>
     <div id="version_switcher_menu" class="dropdown-menu list-group-flush py-0" aria-labelledby="version_switcher_button">
         <dl>
             <dt>Releases</dt>
-            {%- if versions.tags %}
             {%- for item in versions.tags %}
             <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
             {%- endfor %}
-            {%- endif %}
-        </dl>
-        {%- if versions.branches %}
+        </dl>        
         <dl>
             <dt>Branches</dt>
             {%- for item in versions.branches %}
             <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
             {%- endfor %}
-        </dl>
-        {%- endif %}
+        </dl>        
     </div>
 </div>

--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,4 +1,3 @@
-{%- if current_version %}
 <div class="dropdown" id="version_switcher">
     <button type="button" class="btn btn-sm navbar-btn dropdown-toggle" id="version_switcher_button" data-toggle="dropdown">
         {{ current_version.name if current_version.name != "main" else "main-branch" }}
@@ -12,19 +11,6 @@
             <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
             {%- endfor %}
             {%- endif %}
-            <!-- hard-coding the old versions, as no further old version will be added -->
-            <!-- It would be nice if this opened the same page in an older version, but that seems to be overkill
-                 right now. Therefore defaulting to the starting page (index). -->
-            <dd><a href="/dowhy/v0.8/index.html">v0.8</a></dd>
-            <dd><a href="/dowhy/v0.7.1/index.html">v0.7.1</a></dd>
-            <dd><a href="/dowhy/v0.7/index.html">v0.7</a></dd>
-            <dd><a href="/dowhy/v0.6/index.html">v0.6</a></dd>
-            <dd><a href="/dowhy/v0.5.1/index.html">v0.5.1</a></dd>
-            <dd><a href="/dowhy/v0.5/index.html">v0.5</a></dd>
-            <dd><a href="/dowhy/v0.4/index.html">v0.4</a></dd>
-            <dd><a href="/dowhy/v0.2/index.html">v0.2</a></dd>
-            <dd><a href="/dowhy/v0.1.1-alpha/index.html">v0.1.1-alpha</a></dd>
-            <dd><a href="/dowhy/v0.1-alpha/index.html">v0.1-alpha</a></dd>
         </dl>
         {%- if versions.branches %}
         <dl>
@@ -36,4 +22,3 @@
         {%- endif %}
     </div>
 </div>
-{%- endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,19 +21,18 @@ copyright = "2022, PyWhy contributors"
 author = "PyWhy community"
 
 # Version Information (for version-switcher)
-current_version = {"name": os.environ.get("CURRENT_VERSION") or "main"}
-versions = {
-    "tags": list(
-        map(
-            lambda t: {"name": t, "url": f"/dowhy/{t}/index.html"},
-            reversed(list(filter(lambda t: len(t) > 0, os.environ.get("TAGS").split(",")))),
-        )
-    ),
-    "branches": ["main"],
+html_context = {
+    "current_version": {"name": os.environ.get("CURRENT_VERSION")},
+    "versions": {
+        "tags": list(
+            map(
+                lambda t: {"name": t, "url": f"../{t}/index.html"},
+                reversed(list(filter(lambda t: len(t) > 0, os.environ.get("TAGS").split(",")))),
+            )
+        ),
+        "branches": [{"name": "main"}],
+    },
 }
-
-print("Current Verison: ", current_version, "Versions: ", versions)
-
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,10 +14,6 @@
 #
 import os
 
-docs_root = "../../dowhy-docs"
-tags = reversed(list(filter(lambda t: len(t) > 0, os.environ.get("TAGS").split(","))))
-tag_objects = list(map(lambda t: {"name": t, "url": f"/dowhy/{t}/index.html"}, tags))
-
 # -- Project information -----------------------------------------------------
 
 project = "DoWhy"
@@ -26,7 +22,15 @@ author = "PyWhy community"
 
 # Version Information (for version-switcher)
 current_version = {"name": os.environ.get("CURRENT_VERSION") or "main"}
-versions = {"tags": tag_objects, "branches": ["main"]}
+versions = {
+    "tags": list(
+        map(
+            lambda t: {"name": t, "url": f"/dowhy/{t}/index.html"},
+            reversed(list(filter(lambda t: len(t) > 0, os.environ.get("TAGS").split(",")))),
+        )
+    ),
+    "branches": ["main"],
+}
 
 print("Current Verison: ", current_version, "Versions: ", versions)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,6 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-from os import listdir
-from os.path import isdir, join
 
 docs_root = "../../dowhy-docs"
 tags = reversed(list(filter(lambda t: len(t) > 0, os.environ.get("TAGS").split(","))))
@@ -28,8 +26,8 @@ author = "PyWhy community"
 
 # Version Information (for version-switcher)
 current_version = {"name": os.environ.get("CURRENT_VERSION") or "main"}
-
 versions = {"tags": tag_objects, "branches": ["main"]}
+
 print("Current Verison: ", current_version, "Versions: ", versions)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,15 +13,24 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
+from os import listdir
+from os.path import isdir, join
 
-sys.path.insert(0, os.path.abspath("../../"))
+docs_root = "../../dowhy-docs"
+tags = reversed(list(filter(lambda t: len(t) > 0, os.environ.get("TAGS").split(","))))
+tag_objects = list(map(lambda t: {"name": t, "url": f"/dowhy/{t}/index.html"}, tags))
 
 # -- Project information -----------------------------------------------------
 
 project = "DoWhy"
 copyright = "2022, PyWhy contributors"
 author = "PyWhy community"
+
+# Version Information (for version-switcher)
+current_version = {"name": os.environ.get("CURRENT_VERSION") or "main"}
+
+versions = {"tags": tag_objects, "branches": ["main"]}
+print("Current Verison: ", current_version, "Versions: ", versions)
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
* Determine tag-list and current version in generate_docs and pass to Python
* Remove static legacy versions in versions.html; these will be provided in the tag-list.

Note: I'm waiting on some build output to verify the rendered result 🤞 (EDIT: looks okay)
Signed-off-by: Chris Trevino <darthtrevino@gmail.com>