### PR TITLE
Fix issue in gcm plotting with modifying causal_strength object

### DIFF
--- a/dowhy/gcm/util/plotting.py
+++ b/dowhy/gcm/util/plotting.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
 import networkx as nx
@@ -110,6 +111,8 @@ def _plot_causal_graph_networkx(
 
     if causal_strengths is None:
         causal_strengths = {}
+    else:
+        causal_strengths = deepcopy(causal_strengths)
 
     max_strength = 0.0
     for (source, target, strength) in causal_graph.edges(data="CAUSAL_STRENGTH", default=1):

--- a/dowhy/gcm/util/pygraphviz.py
+++ b/dowhy/gcm/util/pygraphviz.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple
 
 import networkx as nx
@@ -18,6 +19,8 @@ def _plot_causal_graph_graphviz(
 ) -> None:
     if causal_strengths is None:
         causal_strengths = {}
+    else:
+        causal_strengths = deepcopy(causal_strengths)
 
     max_strength = 0.0
     for (source, target, strength) in causal_graph.edges(data="CAUSAL_STRENGTH", default=None):

--- a/tests/gcm/util/test_plotting.py
+++ b/tests/gcm/util/test_plotting.py
@@ -21,3 +21,11 @@ def test_plot_adjacency_matrix():
     #  AttributeError: module 'matplotlib.cbook' has no attribute 'is_numlike'
     #  Networkx 2.4+ should fix this issue.
     # plot_adjacency_matrix(causal_graph, is_directed=False)
+
+
+def test_given_causal_strengths_when_plot_graph_then_does_not_modify_input_object():
+    causal_strength = {("X", "Y"): 10}
+
+    plot(nx.DiGraph([("X", "Y"), ("Y", "Z")]), causal_strengths=causal_strength)
+
+    assert causal_strength == {("X", "Y"): 10}


### PR DESCRIPTION
Before, the given causal_strength dictionary was modified within the plotting function, which also impacted the original object. Now, a copy is created internally.

Signed-off-by: Patrick Bloebaum <bloebp@amazon.com>