### PR TITLE
Bug in ignore method of EfficientBackdoor class

### DIFF
--- a/dowhy/causal_identifier/efficient_backdoor.py
+++ b/dowhy/causal_identifier/efficient_backdoor.py
@@ -94,9 +94,7 @@ class EfficientBackdoor:
         causal_vertices = set()
         causal_paths = list(
             nx.all_simple_paths(
-                self.graph._graph,
-                source=self.graph.treatment_name[0],
-                target=self.graph.outcome_name[0],
+                self.graph._graph, source=self.graph.treatment_name[0], target=self.graph.outcome_name[0],
             )
         )
 
@@ -250,9 +248,7 @@ class EfficientBackdoor:
         """
         D = self.build_D()
         _, flow_dict = nx.algorithms.flow.maximum_flow(
-            flowG=D,
-            _s=self.graph.outcome_name[0] + "''",
-            _t=self.graph.treatment_name[0] + "'",
+            flowG=D, _s=self.graph.outcome_name[0] + "''", _t=self.graph.treatment_name[0] + "'",
         )
         queu = [self.graph.outcome_name[0] + "''"]
         S_c = set()

--- a/dowhy/causal_identifier/efficient_backdoor.py
+++ b/dowhy/causal_identifier/efficient_backdoor.py
@@ -94,7 +94,9 @@ class EfficientBackdoor:
         causal_vertices = set()
         causal_paths = list(
             nx.all_simple_paths(
-                self.graph._graph, source=self.graph.treatment_name[0], target=self.graph.outcome_name[0],
+                self.graph._graph,
+                source=self.graph.treatment_name[0],
+                target=self.graph.outcome_name[0],
             )
         )
 
@@ -248,7 +250,9 @@ class EfficientBackdoor:
         """
         D = self.build_D()
         _, flow_dict = nx.algorithms.flow.maximum_flow(
-            flowG=D, _s=self.graph.outcome_name[0] + "''", _t=self.graph.treatment_name[0] + "'",
+            flowG=D,
+            _s=self.graph.outcome_name[0] + "''",
+            _t=self.graph.treatment_name[0] + "'",
         )
         queu = [self.graph.outcome_name[0] + "''"]
         S_c = set()

--- a/dowhy/causal_identifier/efficient_backdoor.py
+++ b/dowhy/causal_identifier/efficient_backdoor.py
@@ -117,9 +117,9 @@ class EfficientBackdoor:
         forbidden = set()
 
         for node in self.causal_vertices():
-            forbidden = forbidden.union(nx.descendants(self.graph._graph, node).union(node))
+            forbidden = forbidden.union(nx.descendants(self.graph._graph, node).union({node}))
 
-        return forbidden.union(self.graph.treatment_name[0])
+        return forbidden.union({self.graph.treatment_name[0]})
 
     def ignore(self):
         """Method to compute the set of ignorable vertices with respect to

--- a/tests/causal_identifiers/example_graphs_efficient.py
+++ b/tests/causal_identifiers/example_graphs_efficient.py
@@ -198,12 +198,7 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
         efficient_adjustment={"R", "T"},
         efficient_minimal_adjustment={"R", "T"},
         efficient_mincost_adjustment={"B", "Q"},
-        costs=[
-            ("B", {"cost": 1}),
-            ("Q", {"cost": 1}),
-            ("R", {"cost": 2}),
-            ("T", {"cost": 2}),
-        ],
+        costs=[("B", {"cost": 1}), ("Q", {"cost": 1}), ("R", {"cost": 2}), ("T", {"cost": 2}),],
     ),
     # A graph where optimal, optimal minimal and optimal min cost are different
     "alldiff_example_graph": dict(
@@ -237,21 +232,7 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
                         edge[source "O" target "Y"]
                         ]
                         """,
-        observed_node_names=[
-            "X",
-            "Y",
-            "K",
-            "O",
-            "W1",
-            "W2",
-            "W3",
-            "W4",
-            "W5",
-            "W6",
-            "W7",
-            "W8",
-            "W9",
-        ],
+        observed_node_names=["X", "Y", "K", "O", "W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8", "W9",],
         conditional_node_names=[],
         efficient_adjustment={"O", "W7", "W8", "W9"},
         efficient_minimal_adjustment={"W7", "W8", "W9"},
@@ -325,13 +306,70 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
             "tissue disorder",
             "neuromusc fatigue",
         },
-        efficient_minimal_adjustment={
-            "team motivation",
-            "previous injury",
-            "tissue disorder",
-            "neuromusc fatigue",
-        },
+        efficient_minimal_adjustment={"team motivation", "previous injury", "tissue disorder", "neuromusc fatigue",},
         efficient_mincost_adjustment={"team motivation", "previous injury", "fitness"},
+        costs=None,
+    ),
+    # A graph for which the algorithm was producing wrong result due to a bug reported by Sara Taheri
+    "taheri_graph1": dict(
+        graph_str="""graph[directed 1 node[id "Z1" label "Z1"]
+                        node[id "Z2" label "Z2"]
+                        node[id "Z3" label "Z3"]
+                        node[id "M1" label "M1"]
+                        node[id "M2" label "M2"]                       
+                        node[id "X" label "X"]
+                        node[id "Y" label "Y"]
+                        edge[source "Z1" target "Z2"]
+                        edge[source "Z2" target "Z3"]
+                        edge[source "Z3" target "Y"]
+                        edge[source "Z1" target "X"]
+                        edge[source "X" target "M1"]
+                        edge[source "M1" target "M2"]
+                        edge[source "M2" target "Y"]
+                        ]
+""",
+        observed_node_names=["Z1", "Z2", "Z3", "X", "Y", "M1", "M2"],
+        conditional_node_names=[],
+        efficient_adjustment={"Z3"},
+        efficient_minimal_adjustment={"Z3"},
+        efficient_mincost_adjustment={"Z3"},
+        costs=None,
+    ),
+    # Another graph for which the algorithm was producing wrong result due to a bug reported by Sara Taheri
+    "taheri_graph2": dict(
+        graph_str="""graph[directed 1 node[id "Z1" label "Z1"]
+                        node[id "Z2" label "Z2"]
+                        node[id "Z3" label "Z3"]
+                        node[id "Z4" label "Z4"]
+                        node[id "Z5" label "Z5"]
+                        node[id "M1" label "M1"]
+                        node[id "M2" label "M2"]                       
+                        node[id "M3" label "M3"]                       
+                        node[id "X" label "X"]
+                        node[id "Y" label "Y"]
+                        node[id "U1" label "U1"]
+                        node[id "U2" label "U2"]
+                        edge[source "Z1" target "Z2"]
+                        edge[source "Z2" target "Z3"]
+                        edge[source "Z3" target "Z4"]
+                        edge[source "Z4" target "Z5"]
+                        edge[source "Z5" target "Y"]
+                        edge[source "Z1" target "X"]
+                        edge[source "X" target "M1"]
+                        edge[source "M1" target "M2"]
+                        edge[source "M2" target "M3"]
+                        edge[source "M3" target "Y"]
+                        edge[source "U1" target "X"]
+                        edge[source "U1" target "Z1"]
+                        edge[source "U2" target "Z2"]
+                        edge[source "U2" target "M1"]
+                        ]
+""",
+        observed_node_names=["Z1", "Z2", "Z3", "Z4", "Z5", "X", "Y", "M1", "M2", "M3"],
+        conditional_node_names=[],
+        efficient_adjustment={"Z1", "Z2", "Z5"},
+        efficient_minimal_adjustment={"Z1"},
+        efficient_mincost_adjustment={"Z1"},
         costs=None,
     ),
 }

--- a/tests/causal_identifiers/example_graphs_efficient.py
+++ b/tests/causal_identifiers/example_graphs_efficient.py
@@ -198,7 +198,12 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
         efficient_adjustment={"R", "T"},
         efficient_minimal_adjustment={"R", "T"},
         efficient_mincost_adjustment={"B", "Q"},
-        costs=[("B", {"cost": 1}), ("Q", {"cost": 1}), ("R", {"cost": 2}), ("T", {"cost": 2}),],
+        costs=[
+            ("B", {"cost": 1}),
+            ("Q", {"cost": 1}),
+            ("R", {"cost": 2}),
+            ("T", {"cost": 2}),
+        ],
     ),
     # A graph where optimal, optimal minimal and optimal min cost are different
     "alldiff_example_graph": dict(
@@ -232,7 +237,21 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
                         edge[source "O" target "Y"]
                         ]
                         """,
-        observed_node_names=["X", "Y", "K", "O", "W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8", "W9",],
+        observed_node_names=[
+            "X",
+            "Y",
+            "K",
+            "O",
+            "W1",
+            "W2",
+            "W3",
+            "W4",
+            "W5",
+            "W6",
+            "W7",
+            "W8",
+            "W9",
+        ],
         conditional_node_names=[],
         efficient_adjustment={"O", "W7", "W8", "W9"},
         efficient_minimal_adjustment={"W7", "W8", "W9"},
@@ -306,7 +325,12 @@ TEST_EFFICIENT_BD_SOLUTIONS = {
             "tissue disorder",
             "neuromusc fatigue",
         },
-        efficient_minimal_adjustment={"team motivation", "previous injury", "tissue disorder", "neuromusc fatigue",},
+        efficient_minimal_adjustment={
+            "team motivation",
+            "previous injury",
+            "tissue disorder",
+            "neuromusc fatigue",
+        },
         efficient_mincost_adjustment={"team motivation", "previous injury", "fitness"},
         costs=None,
     ),


### PR DESCRIPTION
Hi there. Sara Taheri pointed out the [optimaladj](https://github.com/facusapienza21/optimaladj) package was giving the wrong answer in the following simple example:

```
treatment = 'T'
outcome = 'Y'

L = []
N = ['T', 'Z1', 'Z2', 'Z3', 'M1', 'M2', 'Y']

G = CausalGraph()
G.add_edges_from([('Z1', 'Z2'),
                  ('Z1', 'T'),
                  ('Z2', 'Z3'),
                  ('Z3', 'Y'),
                  ('T', 'M1'),
                  ('M1','M2'),
                  ('M2', 'Y')])

G.ignore(treatment, outcome, L, N)
```

The output should be M1, M2, and it is only M2. 

Since doWhy has the same implementation as optimaladj, the analogous error in this package. The error is due to a bug in the method that constructs the forbidden set, specificially [here](https://github.com/py-why/dowhy/pull/777/files#diff-bf4ee8953848928b1341a76af189487030c02acdc46a071183112115c008856aL120). The problem is that when node name has more than one character, each separate character is added to the forbidden set, instead of the whole string.

This PR fixes this and adds new test cases.