### PR TITLE
Updated correct url for dowhy in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = ["PyWhy Community <amshar@microsoft.com>"]
 maintainers = []
 license = "MIT"
 documentation = "https://py-why.github.io/dowhy"
-repository = "https://github.com/pywhy/dowhy"
+repository = "https://github.com/py-why/dowhy"
 classifiers = [
     'Development Status :: 4 - Beta',
     'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
PyPI is picking up an incorrect URL for the latest release. This won't fix the pypi issue until the next release though.

Signed-off-by: Amit Sharma <amit_sharma@live.com>