### PR TITLE
Make autogluon optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ pygraphviz = ["pygraphviz"]
 pydot = ["pydot"]
 plotting = ["matplotlib"]
 causalml = ["causalml", "llvmlite", "cython"]
+autogluon = ["autogluon-tabular"]
 
 [tool.poetry.group.dev.dependencies]
 poethepoet = "^0.16.0"


### PR DESCRIPTION
It looks like since has not been listed in the 'extra' group, it's not marked as optional.

Right now, a `pip install dowhy` pulls in autogluon and pytorch and makes this a pretty large installation. I believe this change should fix this.

Signed-off-by: Peter Goetz <pego@amazon.com>