### PR TITLE
Add color option to graph plotting

### DIFF
--- a/dowhy/gcm/util/pygraphviz.py
+++ b/dowhy/gcm/util/pygraphviz.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from copy import deepcopy
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np
@@ -13,6 +13,7 @@ def _plot_causal_graph_graphviz(
     causal_graph: nx.Graph,
     display_causal_strengths: bool = True,
     causal_strengths: Optional[Dict[Tuple[Any, Any], float]] = None,
+    colors: Optional[Dict[Union[Any, Tuple[Any, Any]], str]] = None,
     filename: Optional[str] = None,
     display_plot: bool = True,
     figure_size: Optional[Tuple[int, int]] = None,
@@ -21,6 +22,10 @@ def _plot_causal_graph_graphviz(
         causal_strengths = {}
     else:
         causal_strengths = deepcopy(causal_strengths)
+    if colors is None:
+        colors = {}
+    else:
+        colors = deepcopy(colors)
 
     max_strength = 0.0
     for (source, target, strength) in causal_graph.edges(data="CAUSAL_STRENGTH", default=None):
@@ -28,14 +33,20 @@ def _plot_causal_graph_graphviz(
             causal_strengths[(source, target)] = strength
         if causal_strengths[(source, target)] is not None:
             max_strength = max(max_strength, abs(causal_strengths[(source, target)]))
+        if (source, target) not in colors:
+            colors[(source, target)] = "black"
 
     pygraphviz_graph = pygraphviz.AGraph(directed=isinstance(causal_graph, nx.DiGraph))
 
     for node in causal_graph.nodes:
-        pygraphviz_graph.add_node(node)
+        if node in colors:
+            pygraphviz_graph.add_node(node, color=colors[node], fontcolor=colors[node])
+        else:
+            pygraphviz_graph.add_node(node)
 
     for (source, target) in causal_graph.edges():
         causal_strength = causal_strengths[(source, target)]
+        color = colors[(source, target)]
         if causal_strength is not None:
             if np.isinf(causal_strength):
                 causal_strength = 10000
@@ -48,9 +59,10 @@ def _plot_causal_graph_graphviz(
                 str(target),
                 label=tmp_label if display_causal_strengths else None,
                 penwidth=str(_calc_arrow_width(causal_strength, max_strength)),
+                color=color,
             )
         else:
-            pygraphviz_graph.add_edge(str(source), str(target))
+            pygraphviz_graph.add_edge(str(source), str(target), color=color)
 
     pygraphviz_graph.layout(prog="dot")
     if filename is not None:

--- a/tests/gcm/util/test_plotting.py
+++ b/tests/gcm/util/test_plotting.py
@@ -29,3 +29,11 @@ def test_given_causal_strengths_when_plot_graph_then_does_not_modify_input_objec
     plot(nx.DiGraph([("X", "Y"), ("Y", "Z")]), causal_strengths=causal_strength)
 
     assert causal_strength == {("X", "Y"): 10}
+
+
+def test_given_colors_when_plot_graph_then_does_not_modify_input_object():
+    colors = {("X", "Y"): "red", "X": "blue"}
+
+    plot(nx.DiGraph([("X", "Y"), ("Y", "Z")]), colors=colors)
+
+    assert colors == {("X", "Y"): "red", "X": "blue"}


### PR DESCRIPTION
Added an optional parameter `colors` when plotting a graph. This can be used to color individual nodes or edges in the graph. E.g. 
```
import networkx as nx
from dowhy.gcm.util import plot
plot(nx.DiGraph([('X0', 'X1'), ('X1', 'X2')]), colors={('X0', 'X1'): 'red', 'X2': 'green'})
```
generates a plot where the edge between X0 and X1 is colored red and the node X2 is colored green. This works with both plotting via pygraphviz and networkx.

Signed-off-by: Elias Eulig <eeulig@amazon.com>