### PR TITLE
Change copyright owner to PyWhy contributors in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
     MIT License
 
-    Copyright (c) Microsoft Corporation. All rights reserved.
+    Copyright (c) PyWhy contributors. All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Post moving to the py-why org, the dowhy license should include copyright of "pywhy contributors".

This PR changes the text in MIT license. 