### PR TITLE
removed causal-ml from poetry setup instructions

### DIFF
--- a/docs/source/contributing/contributing-code.rst
+++ b/docs/source/contributing/contributing-code.rst
@@ -25,7 +25,7 @@ The following steps allow you to contribute code to DoWhy.
 
       cd dowhy
       pip install --upgrade pip
-      poetry install -E "plotting causalml"
+      poetry install -E "plotting"
 
    .. note::
       Installing pygraphviz can cause problems on some platforms.


### PR DESCRIPTION
During december this option was removed from the pyproject.toml. As the current instruction throws an error, it might discourage unexperienced first-time contributors from pursuing, hence the clean up.

Signed-off-by: Michael <marien.mich@gmail.com>