### PR TITLE
Point user guide link to user guide instead of intro

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ structure learning, diagnosis of causal structures, root cause analysis, interve
 
     .. grid-item-card:: User Guide
         :shadow: md
-        :link: user_guide/intro
+        :link: user_guide/index
         :link-type: doc
 
         :octicon:`book;2em;sd-text-info`


### PR DESCRIPTION
This is mainly for consistency, so we can get better aggregate metrics in Google Analytics. For users it probably makes no difference.

Signed-off-by: Peter Goetz <pego@amazon.com>