### PR TITLE
Add docs deps in advanced-on-demand workflow

### DIFF
--- a/.github/workflows/advanced-on-demand.yml
+++ b/.github/workflows/advanced-on-demand.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           echo "installing poetry dependencies"
-          poetry install -E plotting -E pydot -E pygraphviz
+          poetry install -E plotting -E pydot -E pygraphviz --with docs
 
       - name: Run Advanced Tests
         run: poetry run poe test_advanced  --splits 4 --group ${{ matrix.test-group }}


### PR DESCRIPTION
This is required to have all necessary dependencies and it also makes this workflow consistent with the nightly tests. Otherwise the on-demand tests break.

Signed-off-by: Peter Goetz <pego@amazon.com>