### PR TITLE
Fix #832. Randomness by default now.

### DIFF
--- a/dowhy/datasets.py
+++ b/dowhy/datasets.py
@@ -621,7 +621,7 @@ def generate_random_graph(n, max_iter=10):
 
 
 def dataset_from_random_graph(
-    num_vars, num_samples=1000, prob_edge=0.3, random_seed=100, prob_type_of_data=(0.333, 0.333, 0.334)
+    num_vars, num_samples=1000, prob_edge=0.3, random_seed=None, prob_type_of_data=(0.333, 0.333, 0.334)
 ):
     """
     This function generates a dataset with discrete and continuous kinds of variables.
@@ -635,7 +635,9 @@ def dataset_from_random_graph(
     :returns ret_dict : dictionary with information like dataframe, outcome, treatment, graph string and continuous, discrete and binary columns
     """
     assert sum(list(prob_type_of_data)) == 1.0
-    np.random.seed(100)
+    if random_seed is None: 
+        random_seed = np.random.randint(0,1e6)
+    np.random.seed(random_seed)
     DAG = generate_random_graph(n=num_vars)
     mapping = dict(zip(DAG, string.ascii_lowercase))
     DAG = nx.relabel_nodes(DAG, mapping)

--- a/dowhy/datasets.py
+++ b/dowhy/datasets.py
@@ -635,8 +635,8 @@ def dataset_from_random_graph(
     :returns ret_dict : dictionary with information like dataframe, outcome, treatment, graph string and continuous, discrete and binary columns
     """
     assert sum(list(prob_type_of_data)) == 1.0
-    if random_seed is None: 
-        random_seed = np.random.randint(0,1e6)
+    if random_seed is None:
+        random_seed = np.random.randint(0, 1e6)
     np.random.seed(random_seed)
     DAG = generate_random_graph(n=num_vars)
     mapping = dict(zip(DAG, string.ascii_lowercase))


### PR DESCRIPTION
Fix issue with `dowhy.datasets.dataset_from_random_graph()` where the dataset is not generated at random. Previously Numpy random seed was hard set to 100 within the function. I have now also allowed for `random_seed` being selected if not passed into function as a parameter.