### PR TITLE
Bug fix: Missing use of arguments in estimate effect 

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -903,9 +903,7 @@ class CausalEstimate:
             s += "Effect estimates: {0}\n".format(self.cate_estimates)
         if hasattr(self, "estimator"):
             if self.estimator._significance_test:
-                s += "p-value: {0}\n".format(
-                    self.estimator.signif_results_tostr(self.test_stat_significance())
-                )
+                s += "p-value: {0}\n".format(self.estimator.signif_results_tostr(self.test_stat_significance()))
             if self.estimator._confidence_intervals:
                 s += "{0}% confidence interval: {1}\n".format(
                     100 * self.estimator.confidence_level, self.get_confidence_intervals()

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -904,11 +904,11 @@ class CausalEstimate:
         if hasattr(self, "estimator"):
             if self.estimator._significance_test:
                 s += "p-value: {0}\n".format(
-                    self.estimator.signif_results_tostr(self.test_stat_significance(self._data))
+                    self.estimator.signif_results_tostr(self.test_stat_significance())
                 )
             if self.estimator._confidence_intervals:
                 s += "{0}% confidence interval: {1}\n".format(
-                    100 * self.estimator.confidence_level, self.get_confidence_intervals(self._data)
+                    100 * self.estimator.confidence_level, self.get_confidence_intervals()
                 )
         if self.conditional_estimates is not None:
             s += "### Conditional Estimates\n"

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -309,6 +309,9 @@ class CausalModel:
             else:
                 causal_estimator = causal_estimator_class(
                     identified_estimand,
+                    test_significance=test_significance,
+                    evaluate_effect_strength=evaluate_effect_strength,
+                    confidence_intervals=confidence_intervals,
                     **method_params,
                     **extra_args,
                 )


### PR DESCRIPTION
While investigating a [question on discord](https://discord.com/channels/818456847551168542/1068535649566724116/1068892182683070524) I saw that these arguments were not being passed to the constructed estimator anymore.

@amit-sharma Not sure if this is correct. Feel free to let me know if there is a better way to do this.