### PR TITLE
Fix bug in gcm is_probability_matrix function

### DIFF
--- a/dowhy/gcm/divergence.py
+++ b/dowhy/gcm/divergence.py
@@ -92,6 +92,6 @@ def estimate_kl_divergence_of_probabilities(X: np.ndarray, Y: np.ndarray) -> flo
 
 def is_probability_matrix(X: np.ndarray) -> bool:
     if X.ndim == 1:
-        return np.all(np.isclose(np.sum(abs(X), axis=0), 1))
+        return np.all(np.isclose(np.sum(abs(X.astype(np.float64)), axis=0), 1))
     else:
-        return np.all(np.isclose(np.sum(abs(X), axis=1), 1))
+        return np.all(np.isclose(np.sum(abs(X.astype(np.float64)), axis=1), 1))

--- a/tests/gcm/test_divergence.py
+++ b/tests/gcm/test_divergence.py
@@ -68,3 +68,7 @@ def test_given_valid_and_invalid_probability_vectors_when_apply_is_probabilities
     assert not is_probability_matrix(np.array([0.1, 0.3, 0.2]))
     assert is_probability_matrix(np.array([[0.5, 0.3, 0.2], [0.1, 0.2, 0.7]]))
     assert not is_probability_matrix(np.random.normal(0, 1, (5, 3)))
+
+
+def test_given_numpy_array_with_object_dtype_when_check_is_probability_matrix_then_does_not_raise_error():
+    assert not is_probability_matrix(np.array([0, 1, 2], dtype=object))


### PR DESCRIPTION
Before, numeric arrays with the wrong dtype would cause an error when summing them up and using np.isclose. Now, the dtype is explicitly changed to float64.