### PR TITLE
Revise gcm Shapley estimator

### DIFF
--- a/tests/gcm/test_shapley.py
+++ b/tests/gcm/test_shapley.py
@@ -1,11 +1,14 @@
+import itertools
+import math
 import random
+from collections import Counter
 
 import numpy as np
 import pytest
 from flaky import flaky
 from pytest import approx
 
-from dowhy.gcm.shapley import ShapleyApproximationMethods, ShapleyConfig, estimate_shapley_values
+from dowhy.gcm.shapley import ShapleyApproximationMethods, ShapleyConfig, _get_permutation_at, estimate_shapley_values
 from dowhy.gcm.stats import permute_features
 from dowhy.gcm.util.general import means_difference
 
@@ -219,6 +222,16 @@ def test_given_specific_random_seed_when_estimate_shapley_values_with_early_stop
     )
 
     assert shapley_values_1 == approx(shapley_values_2, abs=0)
+
+
+def test_given_all_indices_when_calling_get_permutation_at_then_returns_all_possible_permutations():
+    n_minus_one = math.factorial(7)
+    players = list(range(8))
+    all_permutations = []
+    for i in range(math.factorial(8)):
+        all_permutations.append(_get_permutation_at(players, i, n_minus_one))
+
+    assert Counter(map(tuple, list(itertools.permutations(players)))) == Counter(map(tuple, all_permutations))
 
 
 def _generate_data(num_vars):


### PR DESCRIPTION
- Shapley config parameter now clearly distinguishes between num_subset_sampling and num_permutations
- Using a quasi-random sequence generator now to improve uniform sampling of permutation. This should improve convergence (i.e., more accurate estimations)
- Fix bug in early stopping where one can get negative percentages and, thus, the estimator would falsely stop too early.
- Early stopping criteria is now applied to the change of each Shapley value individually instead of the average change. This should ensure less variance in the results between two runs and more accurate results.
- Change minimum change in percentage threshold to 0.05 by default for early stopping. This balances out the potential slower runtime from the change above.