### PR TITLE
Fix broken links to license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 ## Contributing Guide
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. This Project welcomes contributions, suggestions, and feedback. All contributions, suggestions, and feedback you submitted are accepted under the [Project's license](./LICENSE.md). You represent that if you do not own copyright in the code that you have the authority to submit it under the [Project's license](./LICENSE.md). All feedback, suggestions, or contributions are not confidential.
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. This Project welcomes contributions, suggestions, and feedback. All contributions, suggestions, and feedback you submitted are accepted under the [Project's license](./LICENSE). You represent that if you do not own copyright in the code that you have the authority to submit it under the [Project's license](./LICENSE). All feedback, suggestions, or contributions are not confidential.
 
 There are multiple ways to contribute to DoWhy.
 


### PR DESCRIPTION
The links from the Contributing Guide to the license are broken because the LICENSE file doesn't have an extension.