### PR TITLE
Change default parameters in attribute_anomalies

### DIFF
--- a/dowhy/gcm/anomaly.py
+++ b/dowhy/gcm/anomaly.py
@@ -92,7 +92,7 @@ def attribute_anomalies(
     anomaly_samples: pd.DataFrame,
     anomaly_scorer: Optional[AnomalyScorer] = None,
     attribute_mean_deviation: bool = False,
-    num_distribution_samples: int = 5000,
+    num_distribution_samples: int = 1500,
     shapley_config: Optional[ShapleyConfig] = None,
 ) -> Dict[Any, np.ndarray]:
     """Estimates the contributions of upstream nodes to the anomaly score of the target_node for each sample in


### PR DESCRIPTION
Decrease the default number of distribution samples. This significantly speeds up the calculation without losing much accuracy.