### PR TITLE
Correct import name for autogluon

### DIFF
--- a/docs/source/dowhy.gcm.ml.rst
+++ b/docs/source/dowhy.gcm.ml.rst
@@ -4,10 +4,10 @@ dowhy.gcm.ml package
 Submodules
 ----------
 
-dowhy.gcm.ml.autolguon module
+dowhy.gcm.ml.autogluon module
 -----------------------------
 
-.. automodule:: dowhy.gcm.ml.autolguon
+.. automodule:: dowhy.gcm.ml.autogluon
    :members:
    :undoc-members:
    :show-inheritance:

--- a/dowhy/gcm/auto.py
+++ b/dowhy/gcm/auto.py
@@ -152,7 +152,7 @@ def select_model(
 ) -> Union[PredictionModel, ClassificationModel]:
     if model_selection_quality == AssignmentQuality.BEST:
         try:
-            from dowhy.gcm.ml.autolguon import AutoGluonClassifier, AutoGluonRegressor
+            from dowhy.gcm.ml.autogluon import AutoGluonClassifier, AutoGluonRegressor
 
             if is_categorical(Y):
                 return AutoGluonClassifier()

--- a/dowhy/gcm/ml/__init__.py
+++ b/dowhy/gcm/ml/__init__.py
@@ -27,6 +27,6 @@ from .regression import (
 )
 
 try:
-    from dowhy.gcm.ml.autolguon import AutoGluonClassifier, AutoGluonRegressor
+    from dowhy.gcm.ml.autogluon import AutoGluonClassifier, AutoGluonRegressor
 except ImportError:
     pass

--- a/tests/gcm/ml/test_autogluon.py
+++ b/tests/gcm/ml/test_autogluon.py
@@ -7,7 +7,7 @@ from sklearn.model_selection import train_test_split
 
 from dowhy.gcm.fcms import AdditiveNoiseModel, ClassifierFCM
 
-autolguon = importorskip("dowhy.gcm.ml.autogluon")
+autogluon = importorskip("dowhy.gcm.ml.autogluon")
 from dowhy.gcm.ml.autogluon import AutoGluonClassifier, AutoGluonRegressor
 from dowhy.gcm.util.general import shape_into_2d
 


### PR DESCRIPTION
There was a typo "autolguon" -> "autogluon"