### PR TITLE
Change default parameter in the intrinsic_causal_influence method

### DIFF
--- a/dowhy/gcm/influence.py
+++ b/dowhy/gcm/influence.py
@@ -223,7 +223,7 @@ def intrinsic_causal_influence(
     attribution_func: Optional[Callable[[np.ndarray, np.ndarray], float]] = None,
     num_training_samples: int = 100000,
     num_samples_randomization: int = 1000,
-    num_samples_baseline: int = 1000,
+    num_samples_baseline: int = 2000,
     max_batch_size: int = 250,
     auto_assign_quality: auto.AssignmentQuality = auto.AssignmentQuality.GOOD,
     shapley_config: Optional[ShapleyConfig] = None,


### PR DESCRIPTION
Increased the number of baseline samples from 1000 to 2000. This should give more accurate results without impacting the runtime too much.