### PR TITLE
Fix to ensure that all CATE estimates are returned

### DIFF
--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -235,7 +235,6 @@ class Econml(CausalEstimator):
             X = self._effect_modifiers
 
         X_test = X
-        #self.n_target_units = data.shape[0]
         if X is not None:
             if type(target_units) is pd.DataFrame:
                 X_test = target_units
@@ -243,7 +242,6 @@ class Econml(CausalEstimator):
                 filtered_rows = data.where(target_units)
                 boolean_criterion = np.array(filtered_rows.notnull().iloc[:, 0])
                 X_test = X[boolean_criterion]
-            #self.n_target_units = X_test.shape[0]
         # Changing shape to a list for a singleton value
         # Note that self._control_value is assumed to be a singleton value
         self._treatment_value = parse_state(self._treatment_value)

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -138,7 +138,7 @@ class CausalGraph:
 
         # Adding effect modifiers
         if effect_modifier_names is not None:
-            for node_name in effect_modifier_names: 
+            for node_name in effect_modifier_names:
                 if node_name not in common_cause_names:
                     for outcome in self.outcome_name:
                         self._graph.add_node(node_name, observed="yes")
@@ -359,7 +359,7 @@ class CausalGraph:
                 for path in all_directed_paths:
                     modifiers = modifiers.difference(path)
         # Also add any effect modifiers that could not be auto-detected (e.g., they are also common causes)
-        marked_modifiers = [n for n,ndata in self._graph.nodes(data=True) if "effectmodifier" in ndata]
+        marked_modifiers = [n for n, ndata in self._graph.nodes(data=True) if "effectmodifier" in ndata]
         modifiers = modifiers.union(marked_modifiers)
         return list(modifiers)
 

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -138,7 +138,7 @@ class CausalGraph:
 
         # Adding effect modifiers
         if effect_modifier_names is not None:
-            for node_name in effect_modifier_names:
+            for node_name in effect_modifier_names: 
                 if node_name not in common_cause_names:
                     for outcome in self.outcome_name:
                         self._graph.add_node(node_name, observed="yes")
@@ -147,6 +147,7 @@ class CausalGraph:
                         self._graph.add_edge(node_name, outcome)
                         # self._graph.add_edge(node_name, outcome, style = "dotted", headport="s", tailport="n")
                         # self._graph.add_edge(outcome, node_name, style = "dotted", headport="n", tailport="s") # TODO make the ports more general so that they apply not just to top-bottom node configurations
+                self._graph.nodes[node_name]["effectmodifier"] = True
         if mediator_names is not None:
             for node_name in mediator_names:
                 for treatment, outcome in itertools.product(self.treatment_name, self.outcome_name):
@@ -344,6 +345,7 @@ class CausalGraph:
         return list(causes_1.intersection(causes_2))
 
     def get_effect_modifiers(self, nodes1, nodes2):
+        # Return effect modifiers according to the graph
         modifiers = set()
         for node in nodes2:
             modifiers = modifiers.union(self.get_ancestors(node))
@@ -356,6 +358,9 @@ class CausalGraph:
                 all_directed_paths = nx.all_simple_paths(self._graph, node1, node2)
                 for path in all_directed_paths:
                     modifiers = modifiers.difference(path)
+        # Also add any effect modifiers that could not be auto-detected (e.g., they are also common causes)
+        marked_modifiers = [n for n,ndata in self._graph.nodes(data=True) if "effectmodifier" in ndata]
+        modifiers = modifiers.union(marked_modifiers)
         return list(modifiers)
 
     def get_parents(self, node_name):

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -275,7 +275,7 @@ class CausalModel:
 
         """
 
-        if effect_modifiers is None or len(effect_modifiers) == 0:
+        if effect_modifiers is None:
             effect_modifiers = self._graph.get_effect_modifiers(self._treatment, self._outcome)
 
         if method_name is None:

--- a/tests/causal_estimators/test_econml_estimator.py
+++ b/tests/causal_estimators/test_econml_estimator.py
@@ -287,3 +287,119 @@ class TestEconMLEstimator:
                 },
             },
         )
+    
+    def test_empty_effect_modifier_nograph(self):
+        arr = np.random.normal(size=(500, 5))
+        df = pd.DataFrame(arr, columns=['Y', 'T', 'X', 'W0', 'W1'])
+        model = CausalModel(
+            data = df,
+            treatment = 'T',
+            outcome = 'Y',
+            effect_modifiers = ['X'],
+            common_causes = ['W0', 'W1'],
+            estimand_type="nonparametric-ate"
+        )
+
+        estimand = model.identify_effect()
+        est1 = model.estimate_effect(identified_estimand=estimand,
+                                     effect_modifiers=[],
+                                     method_name="backdoor.econml.dml.LinearDML",
+                                     method_params={"init_params": {"random_state":123},
+                                            "fit_params": {}})                       
+
+        assert est1.cate_estimates.shape == (1,1)
+
+        # A model where X is also a common cause
+        model = CausalModel(
+            data = df,
+            treatment = 'T',
+            outcome = 'Y',
+            effect_modifiers = ['X'],
+            common_causes = ['X', 'W0', 'W1'],
+            estimand_type="nonparametric-ate"
+        )
+
+        estimand = model.identify_effect()
+        est2 = model.estimate_effect(identified_estimand=estimand,
+                                     effect_modifiers=[],
+                                     method_name="backdoor.econml.dml.LinearDML",
+                                     method_params={"init_params": {"random_state":123},
+                                            "fit_params": {}})                       
+
+        assert est2.cate_estimates.shape == (1,1)
+
+    def test_effect_modifier_input(self):
+        arr = np.random.normal(size=(500, 5))
+        df = pd.DataFrame(arr, columns=['Y', 'T', 'X', 'W0', 'W1'])
+        model = CausalModel(
+            data = df,
+            treatment = 'T',
+            outcome = 'Y',
+            effect_modifiers = ['X'],
+            common_causes = ['X', 'W0', 'W1'],
+            estimand_type="nonparametric-ate"
+        )
+
+        estimand = model.identify_effect()
+        est1 = model.estimate_effect(identified_estimand=estimand,
+                                     method_name="backdoor.econml.dml.LinearDML",
+                                     method_params={"init_params": {"random_state":123},
+                                            "fit_params": {}})                       
+
+        # A model where X is also a common cause
+        model = CausalModel(
+            data = df,
+            treatment = 'T',
+            outcome = 'Y',
+            effect_modifiers = ['X'],
+            common_causes = ['X', 'W0', 'W1'],
+            estimand_type="nonparametric-ate"
+        )
+
+        estimand = model.identify_effect()
+        est2 = model.estimate_effect(identified_estimand=estimand,
+                                     effect_modifiers=['X'],
+                                     method_name="backdoor.econml.dml.LinearDML",
+                                     method_params={"init_params": {"random_state":123},
+                                            "fit_params": {}})                       
+
+        assert np.array_equal(est1.cate_estimates, est2.cate_estimates)
+
+    def test_effect_modifier_input2(self):
+        # The case where effect modifier is not a common cause
+        arr = np.random.normal(size=(500, 5))
+        df = pd.DataFrame(arr, columns=['Y', 'T', 'X', 'W0', 'W1'])
+        model = CausalModel(
+            data = df,
+            treatment = 'T',
+            outcome = 'Y',
+            effect_modifiers = ['X'],
+            common_causes = ['W0', 'W1'],
+            estimand_type="nonparametric-ate"
+        )
+
+        estimand = model.identify_effect()
+        est1 = model.estimate_effect(identified_estimand=estimand,
+                                     method_name="backdoor.econml.dml.LinearDML",
+                                     method_params={"init_params": {"random_state":123},
+                                            "fit_params": {}})                       
+
+        # A model where X is also a common cause
+        model = CausalModel(
+            data = df,
+            treatment = 'T',
+            outcome = 'Y',
+            effect_modifiers = ['X'],
+            common_causes = ['W0', 'W1'],
+            estimand_type="nonparametric-ate"
+        )
+
+        estimand = model.identify_effect()
+        est2 = model.estimate_effect(identified_estimand=estimand,
+                                     effect_modifiers=['X'],
+                                     method_name="backdoor.econml.dml.LinearDML",
+                                     method_params={"init_params": {"random_state":123},
+                                            "fit_params": {}})                       
+
+        assert np.array_equal(est1.cate_estimates, est2.cate_estimates)
+

--- a/tests/causal_estimators/test_econml_estimator.py
+++ b/tests/causal_estimators/test_econml_estimator.py
@@ -287,119 +287,124 @@ class TestEconMLEstimator:
                 },
             },
         )
-    
+
     def test_empty_effect_modifier_nograph(self):
         arr = np.random.normal(size=(500, 5))
-        df = pd.DataFrame(arr, columns=['Y', 'T', 'X', 'W0', 'W1'])
+        df = pd.DataFrame(arr, columns=["Y", "T", "X", "W0", "W1"])
         model = CausalModel(
-            data = df,
-            treatment = 'T',
-            outcome = 'Y',
-            effect_modifiers = ['X'],
-            common_causes = ['W0', 'W1'],
-            estimand_type="nonparametric-ate"
+            data=df,
+            treatment="T",
+            outcome="Y",
+            effect_modifiers=["X"],
+            common_causes=["W0", "W1"],
+            estimand_type="nonparametric-ate",
         )
 
         estimand = model.identify_effect()
-        est1 = model.estimate_effect(identified_estimand=estimand,
-                                     effect_modifiers=[],
-                                     method_name="backdoor.econml.dml.LinearDML",
-                                     method_params={"init_params": {"random_state":123},
-                                            "fit_params": {}})                       
+        est1 = model.estimate_effect(
+            identified_estimand=estimand,
+            effect_modifiers=[],
+            method_name="backdoor.econml.dml.LinearDML",
+            method_params={"init_params": {"random_state": 123}, "fit_params": {}},
+        )
 
-        assert est1.cate_estimates.shape == (1,1)
+        assert est1.cate_estimates.shape == (1, 1)
 
         # A model where X is also a common cause
         model = CausalModel(
-            data = df,
-            treatment = 'T',
-            outcome = 'Y',
-            effect_modifiers = ['X'],
-            common_causes = ['X', 'W0', 'W1'],
-            estimand_type="nonparametric-ate"
+            data=df,
+            treatment="T",
+            outcome="Y",
+            effect_modifiers=["X"],
+            common_causes=["X", "W0", "W1"],
+            estimand_type="nonparametric-ate",
         )
 
         estimand = model.identify_effect()
-        est2 = model.estimate_effect(identified_estimand=estimand,
-                                     effect_modifiers=[],
-                                     method_name="backdoor.econml.dml.LinearDML",
-                                     method_params={"init_params": {"random_state":123},
-                                            "fit_params": {}})                       
+        est2 = model.estimate_effect(
+            identified_estimand=estimand,
+            effect_modifiers=[],
+            method_name="backdoor.econml.dml.LinearDML",
+            method_params={"init_params": {"random_state": 123}, "fit_params": {}},
+        )
 
-        assert est2.cate_estimates.shape == (1,1)
+        assert est2.cate_estimates.shape == (1, 1)
 
     def test_effect_modifier_input(self):
         arr = np.random.normal(size=(500, 5))
-        df = pd.DataFrame(arr, columns=['Y', 'T', 'X', 'W0', 'W1'])
+        df = pd.DataFrame(arr, columns=["Y", "T", "X", "W0", "W1"])
         model = CausalModel(
-            data = df,
-            treatment = 'T',
-            outcome = 'Y',
-            effect_modifiers = ['X'],
-            common_causes = ['X', 'W0', 'W1'],
-            estimand_type="nonparametric-ate"
+            data=df,
+            treatment="T",
+            outcome="Y",
+            effect_modifiers=["X"],
+            common_causes=["X", "W0", "W1"],
+            estimand_type="nonparametric-ate",
         )
 
         estimand = model.identify_effect()
-        est1 = model.estimate_effect(identified_estimand=estimand,
-                                     method_name="backdoor.econml.dml.LinearDML",
-                                     method_params={"init_params": {"random_state":123},
-                                            "fit_params": {}})                       
+        est1 = model.estimate_effect(
+            identified_estimand=estimand,
+            method_name="backdoor.econml.dml.LinearDML",
+            method_params={"init_params": {"random_state": 123}, "fit_params": {}},
+        )
 
         # A model where X is also a common cause
         model = CausalModel(
-            data = df,
-            treatment = 'T',
-            outcome = 'Y',
-            effect_modifiers = ['X'],
-            common_causes = ['X', 'W0', 'W1'],
-            estimand_type="nonparametric-ate"
+            data=df,
+            treatment="T",
+            outcome="Y",
+            effect_modifiers=["X"],
+            common_causes=["X", "W0", "W1"],
+            estimand_type="nonparametric-ate",
         )
 
         estimand = model.identify_effect()
-        est2 = model.estimate_effect(identified_estimand=estimand,
-                                     effect_modifiers=['X'],
-                                     method_name="backdoor.econml.dml.LinearDML",
-                                     method_params={"init_params": {"random_state":123},
-                                            "fit_params": {}})                       
+        est2 = model.estimate_effect(
+            identified_estimand=estimand,
+            effect_modifiers=["X"],
+            method_name="backdoor.econml.dml.LinearDML",
+            method_params={"init_params": {"random_state": 123}, "fit_params": {}},
+        )
 
         assert np.array_equal(est1.cate_estimates, est2.cate_estimates)
 
     def test_effect_modifier_input2(self):
         # The case where effect modifier is not a common cause
         arr = np.random.normal(size=(500, 5))
-        df = pd.DataFrame(arr, columns=['Y', 'T', 'X', 'W0', 'W1'])
+        df = pd.DataFrame(arr, columns=["Y", "T", "X", "W0", "W1"])
         model = CausalModel(
-            data = df,
-            treatment = 'T',
-            outcome = 'Y',
-            effect_modifiers = ['X'],
-            common_causes = ['W0', 'W1'],
-            estimand_type="nonparametric-ate"
+            data=df,
+            treatment="T",
+            outcome="Y",
+            effect_modifiers=["X"],
+            common_causes=["W0", "W1"],
+            estimand_type="nonparametric-ate",
         )
 
         estimand = model.identify_effect()
-        est1 = model.estimate_effect(identified_estimand=estimand,
-                                     method_name="backdoor.econml.dml.LinearDML",
-                                     method_params={"init_params": {"random_state":123},
-                                            "fit_params": {}})                       
+        est1 = model.estimate_effect(
+            identified_estimand=estimand,
+            method_name="backdoor.econml.dml.LinearDML",
+            method_params={"init_params": {"random_state": 123}, "fit_params": {}},
+        )
 
         # A model where X is also a common cause
         model = CausalModel(
-            data = df,
-            treatment = 'T',
-            outcome = 'Y',
-            effect_modifiers = ['X'],
-            common_causes = ['W0', 'W1'],
-            estimand_type="nonparametric-ate"
+            data=df,
+            treatment="T",
+            outcome="Y",
+            effect_modifiers=["X"],
+            common_causes=["W0", "W1"],
+            estimand_type="nonparametric-ate",
         )
 
         estimand = model.identify_effect()
-        est2 = model.estimate_effect(identified_estimand=estimand,
-                                     effect_modifiers=['X'],
-                                     method_name="backdoor.econml.dml.LinearDML",
-                                     method_params={"init_params": {"random_state":123},
-                                            "fit_params": {}})                       
+        est2 = model.estimate_effect(
+            identified_estimand=estimand,
+            effect_modifiers=["X"],
+            method_name="backdoor.econml.dml.LinearDML",
+            method_params={"init_params": {"random_state": 123}, "fit_params": {}},
+        )
 
         assert np.array_equal(est1.cate_estimates, est2.cate_estimates)
-


### PR DESCRIPTION
Fixes #890 
The CATE estimates array structure is like this:
![image](https://github.com/py-why/dowhy/assets/1775381/bc0b0b97-dad0-48d1-a750-a7836958f48d)

@kbattocchi Is the estimates array returned by EconML nested like this? Does the structure look good?