### PR TITLE
Extend causal identifier init

### DIFF
--- a/dowhy/causal_identifier/__init__.py
+++ b/dowhy/causal_identifier/__init__.py
@@ -2,10 +2,10 @@ from dowhy.causal_identifier.auto_identifier import (
     AutoIdentifier,
     BackdoorAdjustment,
     EstimandType,
+    construct_backdoor_estimand,
+    construct_frontdoor_estimand,
+    construct_iv_estimand,
     identify_effect_auto,
-    construct_backdoor_estimand, 
-    construct_frontdoor_estimand,   
-    construct_iv_estimand, 
 )
 from dowhy.causal_identifier.id_identifier import IDIdentifier, identify_effect_id
 from dowhy.causal_identifier.identified_estimand import IdentifiedEstimand

--- a/dowhy/causal_identifier/__init__.py
+++ b/dowhy/causal_identifier/__init__.py
@@ -3,6 +3,9 @@ from dowhy.causal_identifier.auto_identifier import (
     BackdoorAdjustment,
     EstimandType,
     identify_effect_auto,
+    construct_backdoor_estimand, 
+    construct_frontdoor_estimand,   
+    construct_iv_estimand, 
 )
 from dowhy.causal_identifier.id_identifier import IDIdentifier, identify_effect_id
 from dowhy.causal_identifier.identified_estimand import IdentifiedEstimand
@@ -17,4 +20,7 @@ __all__ = [
     "IdentifiedEstimand",
     "IDIdentifier",
     "identify_effect",
+    "construct_backdoor_estimand",
+    "construct_frontdoor_estimand",
+    "construct_iv_estimand",
 ]


### PR DESCRIPTION
causal identifier __init__.py now gives access to construct_iv_estimand, construct_frontdoor_estimand, and construct_backdoor_estimand functions available on auto_identifier.py 