### PR TITLE
Add handling of ModuleNotFoundError in plotting function

### DIFF
--- a/dowhy/utils/plotting.py
+++ b/dowhy/utils/plotting.py
@@ -78,7 +78,7 @@ def plot(
                 **kwargs,
             )
 
-    except ImportError:
+    except (ImportError, ModuleNotFoundError):
         from dowhy.utils.networkx_plotting import plot_causal_graph_networkx
 
         _logger.info(


### PR DESCRIPTION
Before, we only caught ImportErrors. However, it can also be that the module has not been installed at all, which would lead to a ModuleNotFoundError instead.