### PR TITLE
Fix p-value error for estimator significance: Updated the outcome variable to "dummy_outcome"

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -491,12 +491,11 @@ class CausalEstimator:
         )
         if do_retest:
             null_estimates = np.zeros(num_null_simulations)
+            new_estimand = copy.deepcopy(self._target_estimand)
+            new_estimand.outcome_variable = ["dummy_outcome"]
             for i in range(num_null_simulations):
                 new_outcome = np.random.permutation(data[self._target_estimand.outcome_variable])
                 new_data = data.assign(dummy_outcome=new_outcome)
-                new_estimand = copy.deepcopy(self._target_estimand)
-                new_estimand.outcome_variable = ["dummy_outcome"]
-                # self._outcome = self._data["dummy_outcome"]
                 new_estimator = self.get_new_estimator_object(
                     new_estimand,
                     test_significance=False,

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -494,9 +494,11 @@ class CausalEstimator:
             for i in range(num_null_simulations):
                 new_outcome = np.random.permutation(data[self._target_estimand.outcome_variable])
                 new_data = data.assign(dummy_outcome=new_outcome)
+                new_estimand = copy.deepcopy(self._target_estimand)
+                new_estimand.outcome_variable = ["dummy_outcome"]
                 # self._outcome = self._data["dummy_outcome"]
                 new_estimator = self.get_new_estimator_object(
-                    self._target_estimand,
+                    new_estimand,
                     test_significance=False,
                     evaluate_effect_strength=False,
                     confidence_intervals=False,


### PR DESCRIPTION
The change to "dummy_outcome" was lost in the refactor, because the refactor extracted the outcome variable from target_estimand. Now creating a copy of the target_estimand.

Fixes #1006 