### PR TITLE
Fix issues with pandas 2.0 in GCM module

### DIFF
--- a/dowhy/gcm/_noise.py
+++ b/dowhy/gcm/_noise.py
@@ -23,10 +23,14 @@ def compute_data_from_noise(causal_model: StructuralCausalModel, noise_data: pd.
 
     for node in sorted_nodes:
         if is_root_node(causal_model.graph, node):
-            data[node] = noise_data[node].to_numpy()
+            data[node] = noise_data[node].to_numpy().squeeze()
         else:
-            data[node] = causal_model.causal_mechanism(node).evaluate(
-                data[get_ordered_predecessors(causal_model.graph, node)].to_numpy(), noise_data[node].to_numpy()
+            data[node] = (
+                causal_model.causal_mechanism(node)
+                .evaluate(
+                    data[get_ordered_predecessors(causal_model.graph, node)].to_numpy(), noise_data[node].to_numpy()
+                )
+                .squeeze()
             )
 
     return data
@@ -40,10 +44,12 @@ def compute_noise_from_data(causal_model: InvertibleStructuralCausalModel, obser
 
     for node in sorted_noise:
         if is_root_node(causal_model.graph, node):
-            noise[node] = observed_data[node].to_numpy()
+            noise[node] = observed_data[node].to_numpy().squeeze()
         else:
-            noise[node] = causal_model.causal_mechanism(node).estimate_noise(
-                observed_data[node].to_numpy(), _parent_samples_of(node, causal_model, observed_data)
+            noise[node] = (
+                causal_model.causal_mechanism(node)
+                .estimate_noise(observed_data[node].to_numpy(), _parent_samples_of(node, causal_model, observed_data))
+                .squeeze()
             )
 
     return noise
@@ -144,13 +150,15 @@ def noise_samples_of_ancestors(
 
         if is_root_node(causal_model.graph, node):
             noise = causal_model.causal_mechanism(node).draw_samples(num_samples).reshape(-1)
-            drawn_noise_samples[node] = noise
-            drawn_samples[node] = noise
+            drawn_noise_samples[node] = noise.squeeze()
+            drawn_samples[node] = noise.squeeze()
         else:
             noise = causal_model.causal_mechanism(node).draw_noise_samples(num_samples).reshape(-1)
-            drawn_noise_samples[node] = noise
-            drawn_samples[node] = causal_model.causal_mechanism(node).evaluate(
-                _parent_samples_of(node, causal_model, drawn_samples), noise
+            drawn_noise_samples[node] = noise.squeeze()
+            drawn_samples[node] = (
+                causal_model.causal_mechanism(node)
+                .evaluate(_parent_samples_of(node, causal_model, drawn_samples), noise)
+                .squeeze()
             )
 
         if node == target_node:

--- a/dowhy/gcm/fitting_sampling.py
+++ b/dowhy/gcm/fitting_sampling.py
@@ -92,11 +92,11 @@ def draw_samples(causal_model: ProbabilisticCausalModel, num_samples: int) -> pd
         causal_mechanism = causal_model.causal_mechanism(node)
 
         if is_root_node(causal_model.graph, node):
-            drawn_samples[node] = causal_mechanism.draw_samples(num_samples).reshape(-1)
+            drawn_samples[node] = causal_mechanism.draw_samples(num_samples).squeeze()
         else:
             drawn_samples[node] = causal_mechanism.draw_samples(
                 _parent_samples_of(node, causal_model, drawn_samples)
-            ).reshape(-1)
+            ).squeeze()
 
     return drawn_samples
 

--- a/tests/gcm/test_noise.py
+++ b/tests/gcm/test_noise.py
@@ -223,6 +223,20 @@ def test_given_nodes_names_are_ints_when_calling_noise_dependent_function_then_d
     noise_dependent_function(np.array([[1]]))
 
 
+def test_given_dataframe_with_object_dtype_using_pandas_v2_when_compute_data_from_noise_then_does_not_raise_error():
+    X0 = np.random.choice(2, 10)
+    X1 = X0 + np.random.normal(0, 1, 10)
+
+    data = pd.DataFrame({"X0": X0, "X1": X1}, dtype=object)
+
+    causal_model = InvertibleStructuralCausalModel(nx.DiGraph([("X0", "X1")]))
+    assign_causal_mechanisms(causal_model, data)
+    fit(causal_model, data)
+
+    # This caused an error before with pandas > 2.0
+    compute_noise_from_data(causal_model, data.iloc[0:1])
+
+
 def _persist_parents(graph: DirectedGraph):
     for node in graph.nodes:
         graph.nodes[node][PARENTS_DURING_FIT] = get_ordered_predecessors(graph, node)


### PR DESCRIPTION
Addresses https://github.com/py-why/dowhy/issues/1020

The issue was that pandas versions prior to 2.0 correctly inferred the data type from an input like `np.array([[2.0]], dtype=object)` (even though the dtype is object). In contrast, pandas 2.0 does not make this inference. However, the two-dimensional value was unintentional in the first place. It should be `np.array([2.0], dtype=object)`, which is then correctly handled across all versions.