### PR TITLE
Change default value of layout in view_model of CausalModel

### DIFF
--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -434,7 +434,7 @@ class CausalModel:
         res = refuter.refute_estimate(show_progress_bar)
         return res
 
-    def view_model(self, layout="dot", size=(8, 6), file_name="causal_model"):
+    def view_model(self, layout=None, size=(8, 6), file_name="causal_model"):
         """View the causal DAG.
 
         :param layout: string specifying the layout of the graph.


### PR DESCRIPTION
Changing the value from "dot" to None. The current default value requires the dot extension to be installed. However, if it is not installed, an error is raised. By default, this should not happen since it is an optional dependency.

Addresses: https://github.com/py-why/dowhy/issues/1041