### PR TITLE
Change use of Protocol from typing instead of typing_extension

### DIFF
--- a/dowhy/graph.py
+++ b/dowhy/graph.py
@@ -5,11 +5,10 @@ the future.
 """
 
 from abc import abstractmethod
-from typing import Any, List
+from typing import Any, List, Protocol
 
 import networkx as nx
 from networkx.algorithms.dag import has_cycle
-from typing_extensions import Protocol
 
 
 class HasNodes(Protocol):


### PR DESCRIPTION
The graph module uses Protocols, which have been natively supported since Python 3.8 (the required minimum version for DoWhy). To support Protocols in earlier Python versions, an extension provided Protocol support. However, this extension can cause compatibility issues with newer versions of other packages. With this change, DoWhy now uses the Protocol implementation that has been available since Python 3.8.