### PR TITLE
Relaxed depedency version requirements for sympy and cython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,13 +52,13 @@ files = ["dowhy/__init__.py"]
 #
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-cython = "^0.29.32"
+cython = ">=0.29.32"
 scipy = ">=1.4.1"
 statsmodels = ">=0.13.5"
 numpy = ">=1.20"
 pandas = ">=1.4.3"
 networkx = ">=2.8.5"
-sympy = "^1.10.1"
+sympy = ">=1.10.1"
 scikit-learn = ">1.0"
 pydot = { version = "^1.4.2", optional = true }
 joblib = ">=1.1.0"


### PR DESCRIPTION
Fixes #1037 