### PR TITLE
Fix issue in bar_plot with misspecified confidence intervals

### DIFF
--- a/dowhy/utils/plotting.py
+++ b/dowhy/utils/plotting.py
@@ -145,12 +145,20 @@ def bar_plot(
 
     if uncertainties is None:
         uncertainties = {node: [values[node], values[node]] for node in values}
+    else:
+        for node in values:
+            if node not in uncertainties:
+                uncertainties[node] = [values[node], values[node]]
 
     figure, ax = plt.subplots(figsize=figure_size)
-    ci_plus = [uncertainties[node][1] - values[node] for node in values.keys()]
-    ci_minus = [values[node] - uncertainties[node][0] for node in values.keys()]
+    ci_plus = np.array([uncertainties[node][1] - values[node] for node in values.keys()])
+    ci_minus = np.array([values[node] - uncertainties[node][0] for node in values.keys()])
+
+    is_negative_yerr = np.logical_or(ci_plus < 0, ci_minus < 0)
+    ci_plus[is_negative_yerr] = 0
+    ci_minus[is_negative_yerr] = 0
+
     yerr = np.array([ci_minus, ci_plus])
-    yerr[abs(yerr) < 10**-7] = 0
     plt.bar(values.keys(), values.values(), yerr=yerr, ecolor="#1E88E5", color="#ff0d57", width=bar_width)
     plt.ylabel(ylabel)
     plt.xticks(rotation=xticks_rotation)

--- a/tests/utils/test_plotting.py
+++ b/tests/utils/test_plotting.py
@@ -4,7 +4,7 @@ import pandas as pd
 from _pytest.python_api import approx
 
 from dowhy.utils import plot, plot_adjacency_matrix
-from dowhy.utils.plotting import _calc_arrow_width
+from dowhy.utils.plotting import _calc_arrow_width, bar_plot
 
 
 def test_when_plot_does_not_raise_exception():
@@ -48,3 +48,11 @@ def test_calc_arrow_width():
     assert _calc_arrow_width(0.5, max_strength=0.5) == approx(4.1, abs=0.01)
     assert _calc_arrow_width(0.35, max_strength=0.5) == approx(2.9, abs=0.01)
     assert _calc_arrow_width(100, max_strength=101) == approx(4.06, abs=0.01)
+
+
+def test_given_misspecified_uncertainties_when_bar_plot_then_does_not_raise_error():
+    bar_plot({"X": 1, "Y": 2, "Z": 3}, uncertainties={"X": (1.1, 0.9), "Y": (1.5, 2.1)})
+    bar_plot({"X": 1, "Y": 2}, uncertainties={"X": (10**-2, 10**-1), "Y": (10**-2, 10**-1)})
+    bar_plot({"X": 1}, uncertainties={"X": (0, 1)})
+    bar_plot({"X": 1}, uncertainties={"X": (0, 0.99999999999)})
+    bar_plot({"X": 1}, uncertainties={"X": (1 - 10**-15, 1 + 10**-15)})


### PR DESCRIPTION
If the confidence intervals are misspecified, e.g., greater lower bound than upper bound, the method threw an error before. This, however, can sometimes happen due to precision errors in some algorithms and lead to random build fails. This change fixes the issue and ignores invalid intervals accordingly.