### PR TITLE
Add compatibility between GCM and CausalModel class

### DIFF
--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -95,9 +95,7 @@ class CausalGraph:
         elif isinstance(graph, str) and re.match(".*graph\s*\[.*\]\s*", graph):
             self._graph = nx.DiGraph(nx.parse_gml(graph))
         else:
-            error_msg = (
-                    "Incorrect format: Please provide graph as a networkx DiGraph, GCM model, or as a string or text file in dot, gml format."
-            )
+            error_msg = "Incorrect format: Please provide graph as a networkx DiGraph, GCM model, or as a string or text file in dot, gml format."
             self.logger.error(error_msg)
             self.logger.error("Error: Incorrect graph format")
             raise ValueError(error_msg)

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -59,7 +59,7 @@ class CausalGraph:
             self._graph = nx.DiGraph(graph)
         elif isinstance(graph, ProbabilisticCausalModel):
             self._graph = nx.DiGraph(graph.graph)
-        elif re.match(r".*\.dot", graph):
+        elif isinstance(graph, str) and re.match(r".*\.dot", graph):
             # load dot file
             try:
                 import pygraphviz as pgv
@@ -74,9 +74,9 @@ class CausalGraph:
                 except Exception as e:
                     self.logger.error("Error: Pydot cannot be loaded. " + str(e))
                     raise e
-        elif re.match(r".*\.gml", graph):
+        elif isinstance(graph, str) and re.match(r".*\.gml", graph):
             self._graph = nx.DiGraph(nx.read_gml(graph))
-        elif re.match(r".*graph\s*\{.*\}\s*", graph):
+        elif isinstance(graph, str) and re.match(r".*graph\s*\{.*\}\s*", graph):
             try:
                 import pygraphviz as pgv
 
@@ -92,11 +92,11 @@ class CausalGraph:
                 except Exception as e:
                     self.logger.error("Error: Pydot cannot be loaded. " + str(e))
                     raise e
-        elif re.match(".*graph\s*\[.*\]\s*", graph):
+        elif isinstance(graph, str) and re.match(".*graph\s*\[.*\]\s*", graph):
             self._graph = nx.DiGraph(nx.parse_gml(graph))
         else:
             error_msg = (
-                "Please provide graph as a networkx DiGraph, GCM model, or as a string or text file in dot, gml format."
+                    "Incorrect format: Please provide graph as a networkx DiGraph, GCM model, or as a string or text file in dot, gml format."
             )
             self.logger.error(error_msg)
             self.logger.error("Error: Incorrect graph format")

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -14,7 +14,7 @@ class CausalGraph:
 
     """Class for creating and modifying the causal graph.
 
-    Accepts a graph string (or a text file) in gml format (preferred) and dot format. Graphviz-like attributes can be set for edges and nodes. E.g. style="dashed" as an edge attribute ensures that the edge is drawn with a dashed line.
+    Accepts a networkx DiGraph, a :py:class:`ProbabilisticCausalModel <dowhy.gcm.ProbabilisticCausalModel`, a graph string (or a text file) in gml format (preferred) or dot format. Graphviz-like attributes can be set for edges and nodes. E.g. style="dashed" as an edge attribute ensures that the edge is drawn with a dashed line.
 
      If a graph string is not given, names of treatment, outcome, and confounders, instruments and effect modifiers (if any) can be provided to create the graph.
     """
@@ -95,18 +95,19 @@ class CausalGraph:
         elif re.match(".*graph\s*\[.*\]\s*", graph):
             self._graph = nx.DiGraph(nx.parse_gml(graph))
         else:
-            self.logger.error(
-                "Error: Please provide graph (as string or text file) in dot, gml format, networkx graph "
-                "or GCM model."
+            error_msg = (
+                "Please provide graph as a networkx DiGraph, GCM model, or as a string or text file in dot, gml format."
             )
+            self.logger.error(error_msg)
             self.logger.error("Error: Incorrect graph format")
-            raise ValueError
+            raise ValueError(error_msg)
 
         if observed_node_names is None and (
             isinstance(graph, nx.DiGraph) or isinstance(graph, ProbabilisticCausalModel)
         ):
             observed_node_names = list(self._graph.nodes)
-
+        # TODO This functionality needs to be deprecated. It is a convenience function but can introduce confusion
+        # as we are now including the option to initialize CausalGraph with DiGraph or GCM model.
         if missing_nodes_as_confounders:
             self._graph = self.add_missing_nodes_as_common_causes(observed_node_names)
         # Adding node attributes

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -22,7 +22,6 @@ init_printing()  # To display symbolic math symbols
 
 
 class CausalModel:
-
     """Main class for storing the causal model state."""
 
     def __init__(

--- a/dowhy/gcm/causal_models.py
+++ b/dowhy/gcm/causal_models.py
@@ -39,8 +39,17 @@ class ProbabilisticCausalModel:
         :param graph_copier: Optional function that can copy a causal graph. Defaults to a networkx.DiGraph
                              constructor.
         """
+        # Todo: Remove after https://github.com/py-why/dowhy/pull/943.
+        from dowhy.causal_graph import CausalGraph
+        from dowhy.causal_model import CausalModel
+
         if graph is None:
             graph = nx.DiGraph()
+        elif isinstance(graph, CausalModel):
+            graph = graph_copier(graph._graph._graph)
+        elif isinstance(graph, CausalGraph):
+            graph = graph_copier(graph._graph)
+
         self.graph = graph
         self.graph_copier = graph_copier
 

--- a/tests/test_causal_model.py
+++ b/tests/test_causal_model.py
@@ -589,5 +589,6 @@ class TestCausalModel(object):
                 graph=nx.Graph([("X", "Y"), ("Y", "Z")]),
             )
 
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_causal_model.py
+++ b/tests/test_causal_model.py
@@ -579,6 +579,15 @@ class TestCausalModel(object):
         assert set(pcm.graph.nodes) == {"X", "Y", "Z"}
         assert set(pcm.graph.edges) == {("X", "Y"), ("Y", "Z")}
 
+    def test_incorrect_graph_format(self):
+        data = pd.DataFrame({"X": [0], "Y": [0], "Z": [0]})
+        with pytest.raises(ValueError, match="Incorrect format:"):
+            model = CausalModel(
+                data=data,
+                treatment="Y",
+                outcome="Z",
+                graph=nx.Graph([("X", "Y"), ("Y", "Z")]),
+            )
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Before, the causal graphs between the GCM and CausalModel part required some additional work to be converted. Now, a GCM can be used to initiate a CausalModel or CausalGraph and vice versa.

This should improve the interoperability and makes it easier to switch between the functionalities.

However, after the change https://github.com/py-why/dowhy/pull/943, this compatibility should be deprecated until the CausalModel and CausalGraph object is removed completely.