### PR TITLE
Updated python publish workflow to support PyPI 2FA

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,12 +6,15 @@ name: Publish Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:
-
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-
+    environment: release
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
 
@@ -35,4 +38,5 @@ jobs:
       run: |
         poetry-dynamic-versioning
         poetry build
-        poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_PASSWORD }}
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
PyPI has moved to 2FA and this is breaking our package publish workflow. So the workflow is now moved to trusted publisher.

Source: https://docs.pypi.org/trusted-publishers/