### PR TITLE
Fixing python publish workflow to run after version tag is created

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,6 +17,8 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
+metadata = false
+format = "{base}"
 
 [tool.poetry-dynamic-versioning.substitution]
 files = ["dowhy/__init__.py"]


### PR DESCRIPTION
On version tag creation, the python publish workflow failed. 

This PR modifies the workflow so that it can be run again and it can fetch the previous tags. 
Also it modifies pyproject.toml such that the version number returned by `poetry-dynamic-versioning`  is a simple string that is exactly the tag version number.

Based on: https://github.com/mtkennerly/poetry-dynamic-versioning/issues/78