### PR TITLE
Fix issue with kernel_based independence tests with object types

### DIFF
--- a/dowhy/gcm/independence_test/kernel.py
+++ b/dowhy/gcm/independence_test/kernel.py
@@ -374,7 +374,7 @@ def _convert_to_numeric(*args) -> List[np.ndarray]:
             if isinstance(X[0, col], bool):
                 X[:, col] = X[:, col].astype(str)
 
-        result.append(auto_apply_encoders(X, auto_fit_encoders(X)))
+        result.append(auto_apply_encoders(X, auto_fit_encoders(X)).astype(float))
 
     return result
 

--- a/tests/gcm/independence_test/test_kernel.py
+++ b/tests/gcm/independence_test/test_kernel.py
@@ -328,6 +328,14 @@ def test_given_almost_constant_data_when_perform_kernel_based_test_then_does_not
     )
 
 
+def test_given_data_with_boolean_and_object_type_when_kernel_based_then_does_not_raise_error():
+    kernel_based(
+        np.array([1, 2, 3, 4, 5, 6], dtype=object),
+        np.array([[1, False], [2, True], [3, False], [4, False], [5, True], [6, True]], dtype=object),
+        np.array([False, True, False, False, True, True], dtype=object),
+    )
+
+
 def _generate_categorical_data(num_samples=1000):
     x = np.random.normal(0, 1, num_samples)
     z = []


### PR DESCRIPTION
The KCI implementation does require the numpy type to be a numerical type explicitly. This commit converts the dtype to 'float' to ensure this.