### PR TITLE
Fix bug with consistency of RegressionEstimator one-hot encoding

### DIFF
--- a/dowhy/utils/encoding.py
+++ b/dowhy/utils/encoding.py
@@ -1,0 +1,62 @@
+import pandas as pd
+from pandas.core.dtypes.common import is_list_like
+from sklearn.preprocessing import OneHotEncoder
+
+
+def one_hot_encode(data: pd.DataFrame, columns=None, drop_first: bool = False, encoder: OneHotEncoder = None):
+    """
+    Replaces pandas' get_dummies with an implementation of sklearn.preprocessing.OneHotEncoder.
+
+    The purpose of replacement is to allow encoding of new data using the same encoder, which ensures that the resulting encodings are consistent.
+
+    If encoder is None, a new instance of sklearn.preprocessing.OneHotEncoder will be created using `fit_transform()`. Otherwise, the existing encoder is used with `fit()`.
+
+    For compatibility with get_dummies, the encoded data will be transformed into a DataFrame.
+
+    In all cases, the return value will be the encoded data and the encoder object (even if passed in). If `data` contains other columns than the
+    dummy-coded one(s), these will be prepended, unaltered, to the result.
+
+    :param data: Data of which to get dummy indicators.
+    :param columns: List-like structure containing specific columns to encode.
+    :param drop_first: Whether to get k-1 dummies out of k categorical levels by removing the first level.
+    :return: DataFrame, OneHotEncoder
+    """
+
+    # Determine columns being encoded
+    if columns is None:
+        dtypes_to_encode = ["object", "string", "category"]
+        data_to_encode = data.select_dtypes(include=dtypes_to_encode)
+    elif not is_list_like(columns):
+        raise TypeError("Input must be a list-like for parameter `columns`")
+    else:
+        data_to_encode = data[columns]
+
+    # If all columns are already numerical, there may be nothing to encode.
+    # In this case, return original data.
+    if len(data_to_encode.columns) == 0:
+        return data, encoder  # Encoder may be None
+
+    # Columns to keep in the result - not encoded.
+    columns_to_keep = data.columns.difference(data_to_encode.columns)
+    df_columns_to_keep = data[columns_to_keep].reset_index(drop=True)
+
+    if encoder is None:  # Create new encoder
+        drop = None
+        if drop_first:
+            drop = "first"
+        encoder = OneHotEncoder(drop=drop, sparse=False)  # NB sparse renamed to sparse_output in sklearn 1.2+
+
+        encoded_data = encoder.fit_transform(data_to_encode)
+
+    else:  # Use existing encoder
+        encoded_data = encoder.transform(data_to_encode)
+
+    # Convert the encoded data to a DataFrame
+    columns_encoded = encoder.get_feature_names_out(data_to_encode.columns)
+
+    df_encoded = pd.DataFrame(encoded_data, columns=columns_encoded).reset_index(drop=True)  # drop index from original
+
+    # Concatenate the encoded DataFrame with the original non-categorical columns
+    df_result = pd.concat([df_columns_to_keep, df_encoded], axis=1)
+
+    return df_result, encoder

--- a/tests/utils/test_encoding.py
+++ b/tests/utils/test_encoding.py
@@ -1,0 +1,87 @@
+import networkx as nx
+import numpy as np
+import pandas as pd
+from _pytest.python_api import approx
+
+from dowhy.utils.encoding import one_hot_encode
+
+
+def test_one_hot_encode_equivalent_to_get_dummies():
+
+    # Use a mix of already-numeric and requires encoding cols:
+    data = {
+        "C": ["X", "Y", "Z", "X", "Y", "Z"],
+        "N": [1, 2, 3, 4, 5, 6],
+    }
+    df = pd.DataFrame(data)
+
+    # NB There may be small differences in type but since all values will be used in models as float,
+    # comparison is done as this type.
+    df_dummies = pd.get_dummies(df, drop_first=True)
+    df_dummies = df_dummies.astype(float)
+
+    df_sklearn, _ = one_hot_encode(df, drop_first=True)
+    df_sklearn = df_sklearn.astype(float)
+
+    # Check same rows
+    len1 = len(df_dummies)
+    len2 = len(df_sklearn)
+    assert len1 == len2
+
+    # Check same number of cols
+    len1 = len(df_dummies.columns)
+    len2 = len(df_sklearn.columns)
+    assert len1 == len2
+
+    # Check values
+    # Calculate the sum of absolute differences between the two DataFrames
+    # - should be zero (excl. floating point error)
+    sum_abs_diff = (df_dummies - df_sklearn).abs().sum().sum()
+    assert sum_abs_diff == approx(0.0)
+
+
+def test_one_hot_encode_consistent_with_new_data():
+
+    # Use a mix of already-numeric and requires encoding cols:
+    data1 = {
+        "C": ["X", "Y", "Z", "X", "Y", "Z"],
+        "N": [1, 2, 3, 4, 5, 6],
+    }
+    df1 = pd.DataFrame(data1)
+
+    # Initial encode
+    df_encoded1, encoder = one_hot_encode(df1, drop_first=True)
+    df_encoded1 = df_encoded1.astype(float)
+
+    # Create new data with permuted rows.
+    # Output shape should be unchanged.
+    data2 = {
+        "C": ["Y", "Z", "X", "X", "Y", "Z"],
+        "N": [1, 2, 3, 4, 5, 6],
+    }
+    df2 = pd.DataFrame(data2)
+
+    # Encode this new data.
+    df_encoded2, _ = one_hot_encode(df2, encoder=encoder, drop_first=True)
+    df_encoded2 = df_encoded2.astype(float)
+
+    # Check same rows
+    len1 = len(df_encoded1)
+    len2 = len(df_encoded2)
+    assert len1 == len2
+
+    # Check same number of cols
+    len1 = len(df_encoded1.columns)
+    len2 = len(df_encoded2.columns)
+    assert len1 == len2
+
+    # Check permuted values are consistent
+    c_y1 = df_encoded1["C_Y"]
+    c_y2 = df_encoded2["C_Y"]
+    assert c_y1[1] == c_y2[0]
+    assert c_y1[4] == c_y2[4]
+
+    c_z1 = df_encoded1["C_Z"]
+    c_z2 = df_encoded2["C_Z"]
+    assert c_z1[2] == c_z2[1]
+    assert c_z1[5] == c_z2[5]


### PR DESCRIPTION
Fix bug with consistency of RegressionEstimator one-hot encoding by switching from pandas get_dummies to sklearn OneHotEncoder.

See issue https://github.com/py-why/dowhy/issues/1111