### PR TITLE
Fix missing import for unit test

### DIFF
--- a/tests/causal_estimators/mock_external_estimator.py
+++ b/tests/causal_estimators/mock_external_estimator.py
@@ -1,1 +1,1 @@
-
+from dowhy.causal_estimators.propensity_score_weighting_estimator import PropensityScoreWeightingEstimator


### PR DESCRIPTION
This should fix the import error for the causal estimator unit tests.