### PR TITLE
Fixes #1028: Updated argument calling for refutation methods 

### DIFF
--- a/dowhy/causal_estimators/distance_matching_estimator.py
+++ b/dowhy/causal_estimators/distance_matching_estimator.py
@@ -105,9 +105,9 @@ class DistanceMatchingEstimator(CausalEstimator):
 
     def fit(
         self,
-        data: pd.DataFrame,
-        exact_match_cols=None,
+        data: pd.DataFrame, 
         effect_modifier_names: Optional[List[str]] = None,
+        exact_match_cols=None
     ):
         """
         Fits the estimator with data for effect estimation
@@ -121,7 +121,7 @@ class DistanceMatchingEstimator(CausalEstimator):
                     methods support this currently.
         """
         self.exact_match_cols = exact_match_cols
-
+        self._fit_params = {'exact_match_cols': exact_match_cols}
         self.reset_encoders()  # Forget any existing encoders
         self._set_effect_modifiers(data, effect_modifier_names)
 

--- a/dowhy/causal_estimators/distance_matching_estimator.py
+++ b/dowhy/causal_estimators/distance_matching_estimator.py
@@ -103,12 +103,7 @@ class DistanceMatchingEstimator(CausalEstimator):
         self.matched_indices_att = None
         self.matched_indices_atc = None
 
-    def fit(
-        self,
-        data: pd.DataFrame, 
-        effect_modifier_names: Optional[List[str]] = None,
-        exact_match_cols=None
-    ):
+    def fit(self, data: pd.DataFrame, effect_modifier_names: Optional[List[str]] = None, exact_match_cols=None):
         """
         Fits the estimator with data for effect estimation
         :param data: data frame containing the data
@@ -121,7 +116,7 @@ class DistanceMatchingEstimator(CausalEstimator):
                     methods support this currently.
         """
         self.exact_match_cols = exact_match_cols
-        self._fit_params = {'exact_match_cols': exact_match_cols}
+        self._fit_params = {"exact_match_cols": exact_match_cols}
         self.reset_encoders()  # Forget any existing encoders
         self._set_effect_modifiers(data, effect_modifier_names)
 

--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -119,6 +119,7 @@ class Econml(CausalEstimator):
         self._set_effect_modifiers(data, effect_modifier_names)
         # Save parameters for later refutter fitting
         self._econml_fit_params = kwargs
+        self._fit_params = kwargs
 
         self._observed_common_causes_names = self._target_estimand.get_backdoor_variables().copy()
 

--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -842,8 +842,8 @@ def sensitivity_simulation(
         new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
         new_estimator.fit(
             new_data,
-            estimate.estimator._effect_modifier_names,
-            **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+            effect_modifier_names=estimate.estimator._effect_modifier_names,
+            **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
         )
         new_effect = new_estimator.estimate_effect(
             new_data,
@@ -890,8 +890,8 @@ def sensitivity_simulation(
                     new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
                     new_estimator.fit(
                         new_data,
-                        estimate.estimator._effect_modifier_names,
-                        **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+                        effect_modifier_names=estimate.estimator._effect_modifier_names,
+                        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
                     )
                     new_effect = new_estimator.estimate_effect(
                         new_data,
@@ -966,8 +966,8 @@ def sensitivity_simulation(
                 new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
                 new_estimator.fit(
                     new_data,
-                    estimate.estimator._effect_modifier_names,
-                    **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+                    effect_modifier_names=estimate.estimator._effect_modifier_names,
+                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
                 )
                 new_effect = new_estimator.estimate_effect(
                     new_data,
@@ -1024,8 +1024,8 @@ def sensitivity_simulation(
                 new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
                 new_estimator.fit(
                     new_data,
-                    estimate.estimator._effect_modifier_names,
-                    **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+                    effect_modifier_names=estimate.estimator._effect_modifier_names,
+                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
                 )
                 new_effect = new_estimator.estimate_effect(
                     new_data,

--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -843,7 +843,7 @@ def sensitivity_simulation(
         new_estimator.fit(
             new_data,
             effect_modifier_names=estimate.estimator._effect_modifier_names,
-            **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+            **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
         )
         new_effect = new_estimator.estimate_effect(
             new_data,
@@ -891,7 +891,7 @@ def sensitivity_simulation(
                     new_estimator.fit(
                         new_data,
                         effect_modifier_names=estimate.estimator._effect_modifier_names,
-                        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+                        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
                     )
                     new_effect = new_estimator.estimate_effect(
                         new_data,
@@ -967,7 +967,7 @@ def sensitivity_simulation(
                 new_estimator.fit(
                     new_data,
                     effect_modifier_names=estimate.estimator._effect_modifier_names,
-                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
                 )
                 new_effect = new_estimator.estimate_effect(
                     new_data,
@@ -1025,7 +1025,7 @@ def sensitivity_simulation(
                 new_estimator.fit(
                     new_data,
                     effect_modifier_names=estimate.estimator._effect_modifier_names,
-                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
                 )
                 new_effect = new_estimator.estimate_effect(
                     new_data,

--- a/dowhy/causal_refuters/bootstrap_refuter.py
+++ b/dowhy/causal_refuters/bootstrap_refuter.py
@@ -133,7 +133,7 @@ def _refute_once(
     new_estimator.fit(
         new_data,
         effect_modifier_names=estimate.estimator._effect_modifier_names,
-        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
     )
     new_effect = new_estimator.estimate_effect(
         new_data,

--- a/dowhy/causal_refuters/bootstrap_refuter.py
+++ b/dowhy/causal_refuters/bootstrap_refuter.py
@@ -132,8 +132,8 @@ def _refute_once(
     new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
     new_estimator.fit(
         new_data,
-        estimate.estimator._effect_modifier_names,
-        **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+        effect_modifier_names=estimate.estimator._effect_modifier_names,
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
     )
     new_effect = new_estimator.estimate_effect(
         new_data,

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -76,8 +76,8 @@ def _refute_once(
     new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
     new_estimator.fit(
         new_data,
-        estimate.estimator._effect_modifier_names,
-        **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+        effect_modifier_names=estimate.estimator._effect_modifier_names,
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
     )
     new_effect = new_estimator.estimate_effect(
         new_data,

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -77,7 +77,7 @@ def _refute_once(
     new_estimator.fit(
         new_data,
         effect_modifier_names=estimate.estimator._effect_modifier_names,
-        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
     )
     new_effect = new_estimator.estimate_effect(
         new_data,

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -494,7 +494,7 @@ def refute_dummy_outcome(
             new_estimator.fit(
                 new_data,
                 effect_modifier_names=estimate.estimator._effect_modifier_names,
-                **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+                **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
             )
             new_effect = new_estimator.estimate_effect(
                 new_data,
@@ -574,7 +574,7 @@ def refute_dummy_outcome(
                 new_estimator.fit(
                     new_data,
                     effect_modifier_names=estimate.estimator._effect_modifier_names,
-                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
                 )
                 new_effect = new_estimator.estimate_effect(
                     new_data,

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -493,8 +493,8 @@ def refute_dummy_outcome(
             new_estimator = estimate.estimator.get_new_estimator_object(identified_estimand)
             new_estimator.fit(
                 new_data,
-                estimate.estimator._effect_modifier_names,
-                **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+                effect_modifier_names=estimate.estimator._effect_modifier_names,
+                **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
             )
             new_effect = new_estimator.estimate_effect(
                 new_data,
@@ -573,8 +573,8 @@ def refute_dummy_outcome(
                 new_estimator = estimate.estimator.get_new_estimator_object(identified_estimand)
                 new_estimator.fit(
                     new_data,
-                    estimate.estimator._effect_modifier_names,
-                    **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+                    effect_modifier_names=estimate.estimator._effect_modifier_names,
+                    **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
                 )
                 new_effect = new_estimator.estimate_effect(
                     new_data,

--- a/dowhy/causal_refuters/evalue_sensitivity_analyzer.py
+++ b/dowhy/causal_refuters/evalue_sensitivity_analyzer.py
@@ -261,8 +261,8 @@ class EValueSensitivityAnalyzer:
             new_estimator = self.estimate.estimator.get_new_estimator_object(new_estimand)
             new_estimator.fit(
                 self.data,
-                self.estimate.estimator._effect_modifier_names,
-                **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+                effect_modifier_names=self.estimate.estimator._effect_modifier_names,
+                **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
             )
 
             # new effect estimate

--- a/dowhy/causal_refuters/evalue_sensitivity_analyzer.py
+++ b/dowhy/causal_refuters/evalue_sensitivity_analyzer.py
@@ -262,7 +262,7 @@ class EValueSensitivityAnalyzer:
             new_estimator.fit(
                 self.data,
                 effect_modifier_names=self.estimate.estimator._effect_modifier_names,
-                **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+                **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
             )
 
             # new effect estimate

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -154,8 +154,8 @@ def _refute_once(
     new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
     new_estimator.fit(
         new_data,
-        estimate.estimator._effect_modifier_names,
-        **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+        effect_modifier_names=estimate.estimator._effect_modifier_names,
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
     )
     new_effect = new_estimator.estimate_effect(
         new_data,

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -155,7 +155,7 @@ def _refute_once(
     new_estimator.fit(
         new_data,
         effect_modifier_names=estimate.estimator._effect_modifier_names,
-        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
     )
     new_effect = new_estimator.estimate_effect(
         new_data,

--- a/dowhy/causal_refuters/random_common_cause.py
+++ b/dowhy/causal_refuters/random_common_cause.py
@@ -71,7 +71,7 @@ def _refute_once(
     new_estimator.fit(
         new_data,
         effect_modifier_names=estimate.estimator._effect_modifier_names,
-        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {},
     )
     new_effect = new_estimator.estimate_effect(
         new_data,

--- a/dowhy/causal_refuters/random_common_cause.py
+++ b/dowhy/causal_refuters/random_common_cause.py
@@ -70,8 +70,8 @@ def _refute_once(
     new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
     new_estimator.fit(
         new_data,
-        estimate.estimator._effect_modifier_names,
-        **new_estimator._econml_fit_params if isinstance(new_estimator, Econml) else {},
+        effect_modifier_names=estimate.estimator._effect_modifier_names,
+        **new_estimator._fit_params if hasattr(new_estimator, "_fit_params") else {}
     )
     new_effect = new_estimator.estimate_effect(
         new_data,


### PR DESCRIPTION
Fixes #1028

When calling `fit` inside refutation methods, the `effect_modifier_names` was passed without name. Now it is a named parameter and avoids getting mixed up with other parameters. 
Also generalized `econml_fit_params` to `fit_params` since other methods can also have `fit_params`.