### PR TITLE
Use numpy tile instead of matrix

### DIFF
--- a/dowhy/gcm/stats.py
+++ b/dowhy/gcm/stats.py
@@ -1,7 +1,6 @@
 from typing import Callable, List, Optional, Union
 
 import numpy as np
-from numpy.matlib import repmat
 from scipy import stats
 from sklearn.linear_model import LinearRegression
 
@@ -146,7 +145,7 @@ def marginal_expectation(
     # baseline_noise_samples.shape[0] * feature_samples.shape[0]. Here, we reduce it to
     # batch_size * feature_samples.shape[0]. If the batch_size would be set 1, then each baseline_noise_samples is
     # evaluated one by one in a for-loop.
-    inputs = repmat(feature_samples, batch_size, 1)
+    inputs = np.tile(feature_samples, (batch_size, 1))
     for offset in range(0, baseline_samples.shape[0], batch_size):
         # Each batch consist of at most batch_size * feature_samples.shape[0] many samples. If there are multiple
         # batches, the offset indicates the index of the current baseline_noise_samples that has not been evaluated yet.


### PR DESCRIPTION
May fix:

```
dowhy/gcm/stats.py:4: PendingDeprecationWarning: Importing from numpy.matlib is deprecated since 1.19.0. The matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray. 
    from numpy.matlib import repmat
```

I couldn't run the tests on my laptop because it's not powerful enough.