### PR TITLE
Minor variable name fix in documentation

### DIFF
--- a/docs/source/example_notebooks/dowhy_causal_discovery_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_causal_discovery_example.ipynb
@@ -476,11 +476,11 @@
    ],
    "source": [
     "from causallearn.search.FCMBased import lingam\n",
-    "model = lingam.ICALiNGAM()\n",
-    "model.fit(data)\n",
+    "model_lingam = lingam.ICALiNGAM()\n",
+    "model_lingam.fit(data)\n",
     "\n",
     "from causallearn.search.FCMBased.lingam.utils import make_dot\n",
-    "make_dot(model.adjacency_matrix_, labels=labels)"
+    "make_dot(model_lingam.adjacency_matrix_, labels=labels)"
    ]
   },
   {
@@ -532,7 +532,7 @@
    ],
    "source": [
     "# Obtain valid dot format\n",
-    "graph_dot = make_graph(model.adjacency_matrix_, labels=labels)\n",
+    "graph_dot = make_graph(model_lingam.adjacency_matrix_, labels=labels)\n",
     "\n",
     "# Define Causal Model\n",
     "model=CausalModel(\n",


### PR DESCRIPTION
The variable `model` was used for both Lingam and CausalModel in the notebook (https://www.pywhy.org/dowhy/main/example_notebooks/dowhy_causal_discovery_example.html) which I found a bit confusing when playing around. This PR renames one of the uses of the variable `model` into `model_lingam`.

Related PR: https://github.com/py-why/dowhy/issues/859