### PR TITLE
Update dowhy_causal_discovery_example.ipynb

### DIFF
--- a/docs/source/example_notebooks/dowhy_causal_discovery_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_causal_discovery_example.ipynb
@@ -599,7 +599,7 @@
     "\n",
     "data_sachs, labels = load_dataset(\"sachs\")\n",
     "\n",
-    "print(data.shape)\n",
+    "print(data_sachs.shape)\n",
     "print(labels)"
    ]
   },


### PR DESCRIPTION
the _sachs_ data set is assigned to a variable `data_sachs` but the print statement is for a variable data `data`, resulting in an error when running the notebook