### PR TITLE
Fix typos, 'Falsificaton' -> 'Falsification'

### DIFF
--- a/docs/source/user_guide/modeling_gcm/draw_samples.rst
+++ b/docs/source/user_guide/modeling_gcm/draw_samples.rst
@@ -66,7 +66,7 @@ make use of the evaluation module:
 
     ==== Evaluation of the Causal Graph Structure ====
     +-------------------------------------------------------------------------------------------------------+
-    |                                         Falsificaton Summary                                          |
+    |                                         Falsification Summary                                          |
     +-------------------------------------------------------------------------------------------------------+
     | The given DAG is not informative because 2 / 6 of the permutations lie in the Markov                  |
     | equivalence class of the given DAG (p-value: 0.33).                                                   |

--- a/docs/source/user_guide/modeling_gcm/model_evaluation.rst
+++ b/docs/source/user_guide/modeling_gcm/model_evaluation.rst
@@ -191,7 +191,7 @@ performance and whether our assumptions hold:
 
     ==== Evaluation of the Causal Graph Structure ====
     +-------------------------------------------------------------------------------------------------------+
-    |                                         Falsificaton Summary                                          |
+    |                                         Falsification Summary                                          |
     +-------------------------------------------------------------------------------------------------------+
     | The given DAG is not informative because 2 / 6 of the permutations lie in the Markov                  |
     | equivalence class of the given DAG (p-value: 0.33).                                                   |

--- a/dowhy/gcm/falsify.py
+++ b/dowhy/gcm/falsify.py
@@ -783,7 +783,7 @@ def plot_local_insights(
 
 
 def _generate_table(
-    validation_repr, suggestion_repr, width=105, validation_name="Falsificaton Summary", suggestion_name="Suggestions"
+    validation_repr, suggestion_repr, width=105, validation_name="Falsification Summary", suggestion_name="Suggestions"
 ):
     # Create Validation header
     _repr = [


### PR DESCRIPTION
A super minor PR, just correcting three instances of "Falsification" being mis-spelled as "Falsificaton".