### PR TITLE
Fix incorrect edges in `adjacency_matrix_to_graph`

### DIFF
--- a/dowhy/utils/graph_operations.py
+++ b/dowhy/utils/graph_operations.py
@@ -1,7 +1,6 @@
 import re
 from queue import LifoQueue
 
-import graphviz
 import networkx as nx
 import numpy as np
 from networkx.algorithms.dag import is_directed_acyclic_graph
@@ -38,6 +37,7 @@ def adjacency_matrix_to_graph(adjacency_matrix, labels=None):
     :param labels: List of labels.
     :returns: Graph in DOT format.
     """
+    import graphviz
 
     if adjacency_matrix.ndim != 2:
         raise ValueError("Adjacency matrix must have a dimension of 2.")
@@ -57,8 +57,10 @@ def adjacency_matrix_to_graph(adjacency_matrix, labels=None):
     for label in labels:
         d.node(label)
 
-    for from_, to, coef in zip(dirs[0], dirs[1], adjacency_matrix[idx]):
+    for to, from_, coef in zip(dirs[0], dirs[1], adjacency_matrix[idx]):
         d.edge(labels[from_], labels[to], label=str(coef))
+
+    return d
 
 
 def str_to_dot(string):

--- a/dowhy/utils/graph_operations.py
+++ b/dowhy/utils/graph_operations.py
@@ -1,6 +1,7 @@
 import re
 from queue import LifoQueue
 
+import graphviz
 import networkx as nx
 import numpy as np
 from networkx.algorithms.dag import is_directed_acyclic_graph
@@ -37,18 +38,27 @@ def adjacency_matrix_to_graph(adjacency_matrix, labels=None):
     :param labels: List of labels.
     :returns: Graph in DOT format.
     """
+
+    if adjacency_matrix.ndim != 2:
+        raise ValueError("Adjacency matrix must have a dimension of 2.")
+
+    if isinstance(adjacency_matrix, np.matrix):
+        adjacency_matrix = np.asarray(adjacency_matrix)
+
     # Only consider edges have absolute edge weight > 0.01
     idx = np.abs(adjacency_matrix) > 0.01
     dirs = np.where(idx)
-    import graphviz
 
     d = graphviz.Digraph(engine="dot")
-    names = labels if labels else [f"x{i}" for i in range(len(adjacency_matrix))]
-    for name in names:
-        d.node(name)
-    for to, from_, coef in zip(dirs[0], dirs[1], adjacency_matrix[idx]):
-        d.edge(names[from_], names[to], label=str(coef))
-    return d
+
+    if labels is None:
+        labels = [f"x{i}" for i in range(len(adjacency_matrix))]
+
+    for label in labels:
+        d.node(label)
+
+    for from_, to, coef in zip(dirs[0], dirs[1], adjacency_matrix[idx]):
+        d.edge(labels[from_], labels[to], label=str(coef))
 
 
 def str_to_dot(string):


### PR DESCRIPTION
This PR fixes the issue of incorrect edges in `adjacency_matrix_to_graph` when the adjacency matrix is of type `np.matrix` by converting the matrix into a numpy array.

Related issue: https://github.com/py-why/dowhy/issues/887