### PR TITLE
Change default parameters of ICC for speedup

### DIFF
--- a/dowhy/gcm/influence.py
+++ b/dowhy/gcm/influence.py
@@ -219,9 +219,9 @@ def intrinsic_causal_influence(
     prediction_model: Union[PredictionModel, ClassificationModel, str] = "approx",
     attribution_func: Optional[Callable[[np.ndarray, np.ndarray], float]] = None,
     num_training_samples: int = 100000,
-    num_samples_randomization: int = 1000,
-    num_samples_baseline: int = 2000,
-    max_batch_size: int = 250,
+    num_samples_randomization: int = 250,
+    num_samples_baseline: int = 1000,
+    max_batch_size: int = -1,
     auto_assign_quality: auto.AssignmentQuality = auto.AssignmentQuality.GOOD,
     shapley_config: Optional[ShapleyConfig] = None,
 ) -> Dict[Any, float]:


### PR DESCRIPTION
Taking less samples to estimate ICC. This might lead to higher variance in the estimate, but speeds it up by multiple factors.