### PR TITLE
Change OneHotEncoder parameter from "sparse" to "sparse_output"

### DIFF
--- a/dowhy/causal_refuters/overrule/BCS/load_process_data_BCS.py
+++ b/dowhy/causal_refuters/overrule/BCS/load_process_data_BCS.py
@@ -99,7 +99,7 @@ class FeatureBinarizer(TransformerMixin):
             # Categorical column
             elif (c in self.colCateg) or (data[c].dtype == "object"):
                 # OneHotEncoder object
-                enc[c] = OneHotEncoder(sparse=False, dtype=int, handle_unknown="ignore")
+                enc[c] = OneHotEncoder(sparse_output=False, dtype=int, handle_unknown="ignore")
                 # Fit to observed categories
                 enc[c].fit(data[[c]])
 

--- a/dowhy/utils/encoding.py
+++ b/dowhy/utils/encoding.py
@@ -44,7 +44,7 @@ def one_hot_encode(data: pd.DataFrame, columns=None, drop_first: bool = False, e
         drop = None
         if drop_first:
             drop = "first"
-        encoder = OneHotEncoder(drop=drop, sparse=False)  # NB sparse renamed to sparse_output in sklearn 1.2+
+        encoder = OneHotEncoder(drop=drop, sparse_output=False)  # NB sparse renamed to sparse_output in sklearn 1.2+
 
         encoded_data = encoder.fit_transform(data_to_encode)
 


### PR DESCRIPTION
The "sparse" parameter is deprecated and was renamed to "sparse_output".