### PR TITLE
docs: small fix in user guide

### DIFF
--- a/docs/source/user_guide/modeling_gcm/estimating_confidence_intervals.rst
+++ b/docs/source/user_guide/modeling_gcm/estimating_confidence_intervals.rst
@@ -116,7 +116,7 @@ trained graph. To do this conveniently, the GCM package provides a function
 >>> data = pd.DataFrame(dict(X=X, Y=Y, Z=Z))
 >>>
 >>> causal_model = gcm.StructuralCausalModel(nx.DiGraph([('Z', 'Y'), ('Z', 'X'), ('X', 'Y')]))
->>> gcm.auto.assign_causal_mechanisms(causal_model, data_old)
+>>> gcm.auto.assign_causal_mechanisms(causal_model, data)
 
 we can now use ``fit_and_compute`` as follows:
 


### PR DESCRIPTION
I believe that this was a copy-paste error, as the `data_old` variable was used in an example above.