### PR TITLE
list out docsite contents pre-publish

### DIFF
--- a/docs/generate_docs.sh
+++ b/docs/generate_docs.sh
@@ -59,3 +59,9 @@ echo "<html>
         <meta http-equiv="'"'"refresh"'"'" content="'"'"0; url=./${STABLE_VERSION}"'"'" />
     </head>
 </html>" > ${DOCS_ROOT}/index.html
+
+echo "Docsite ready, listing contents..."
+
+find ${DOCS_ROOT}
+
+echo "finished generate_contents.sh"


### PR DESCRIPTION
This PR is an attempt to debug GH action failures wrt docsite publication. This lists out the content of the docsite to be pushed prior to synchronizing it.