### PR TITLE
Add support for non-singleton treatment/outcome sets to "has_directed_path" method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,11 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm
+.idea/
+*.iml
+*.iws
+
 # Rope project settings
 .ropeproject
 

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -447,14 +447,14 @@ class CausalGraph:
         # convert the outputted generator into a list
         return [p for p in nx.all_simple_paths(self._graph, source=node1, target=node2)]
 
-    def has_directed_path(self, nodes1, nodes2):
+    def has_directed_path(self, action_nodes, outcome_nodes):
         """Checks if there is any directed path between two sets of nodes.
 
         Returns True if and only if every one of the treatments has at least one direct
         path to one of the outcomes. And, every one of the outcomes has a direct path from
         at least one of the treatments.
         """
-        return has_directed_path(self._graph, nodes1[0], nodes2[0])
+        return has_directed_path(self._graph, action_nodes, outcome_nodes)
 
     def get_adjacency_matrix(self, *args, **kwargs):
         """

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -5,6 +5,7 @@ import re
 import networkx as nx
 
 from dowhy.gcm.causal_models import ProbabilisticCausalModel
+from dowhy.graph import has_directed_path
 from dowhy.utils.api import parse_state
 from dowhy.utils.graph_operations import daggity_to_dot
 from dowhy.utils.plotting import plot
@@ -449,11 +450,11 @@ class CausalGraph:
     def has_directed_path(self, nodes1, nodes2):
         """Checks if there is any directed path between two sets of nodes.
 
-        Currently only supports singleton sets.
+        Returns True if and only if every one of the treatments has at least one direct
+        path to one of the outcomes. And, every one of the outcomes has a direct path from
+        at least one of the treatments.
         """
-        # dpaths = self.get_all_directed_paths(nodes1, nodes2)
-        # return len(dpaths) > 0
-        return nx.has_path(self._graph, nodes1[0], nodes2[0])
+        return has_directed_path(self._graph, nodes1[0], nodes2[0])
 
     def get_adjacency_matrix(self, *args, **kwargs):
         """

--- a/dowhy/graph.py
+++ b/dowhy/graph.py
@@ -273,11 +273,19 @@ def get_all_directed_paths(graph: nx.DiGraph, nodes1, nodes2):
 def has_directed_path(graph: nx.DiGraph, nodes1, nodes2):
     """Checks if there is any directed path between two sets of nodes.
 
-    Currently only supports singleton sets.
+    Returns True if and only if every one of the treatments has at least one direct
+    path to one of the outcomes. And, every one of the outcomes has a direct path from
+    at least one of the treatments.
     """
     # dpaths = self.get_all_directed_paths(nodes1, nodes2)
     # return len(dpaths) > 0
-    return nx.has_path(graph, nodes1[0], nodes2[0])
+    outcome_node_candidates = set()
+    action_node_candidates = set()
+    for node in nodes1:
+        outcome_node_candidates.update(nx.descendants(graph, node))
+    for node in nodes2:
+        action_node_candidates.update(nx.ancestors(graph, node))
+    return set(nodes2).issubset(outcome_node_candidates) and set(nodes1).issubset(action_node_candidates)
 
 
 def check_valid_mediation_set(graph: nx.DiGraph, nodes1, nodes2, candidate_nodes, mediation_paths=None):

--- a/dowhy/graph.py
+++ b/dowhy/graph.py
@@ -270,7 +270,7 @@ def get_all_directed_paths(graph: nx.DiGraph, nodes1, nodes2):
     return [p for p in nx.all_simple_paths(graph, source=nodes1[0], target=nodes2[0])]
 
 
-def has_directed_path(graph: nx.DiGraph, nodes1, nodes2):
+def has_directed_path(graph: nx.DiGraph, action_nodes, outcome_nodes):
     """Checks if there is any directed path between two sets of nodes.
 
     Returns True if and only if every one of the treatments has at least one direct
@@ -279,11 +279,11 @@ def has_directed_path(graph: nx.DiGraph, nodes1, nodes2):
     """
     outcome_node_candidates = set()
     action_node_candidates = set()
-    for node in nodes1:
+    for node in action_nodes:
         outcome_node_candidates.update(nx.descendants(graph, node))
-    for node in nodes2:
+    for node in outcome_nodes:
         action_node_candidates.update(nx.ancestors(graph, node))
-    return set(nodes2).issubset(outcome_node_candidates) and set(nodes1).issubset(action_node_candidates)
+    return set(outcome_nodes).issubset(outcome_node_candidates) and set(action_nodes).issubset(action_node_candidates)
 
 
 def check_valid_mediation_set(graph: nx.DiGraph, nodes1, nodes2, candidate_nodes, mediation_paths=None):

--- a/dowhy/graph.py
+++ b/dowhy/graph.py
@@ -277,8 +277,6 @@ def has_directed_path(graph: nx.DiGraph, nodes1, nodes2):
     path to one of the outcomes. And, every one of the outcomes has a direct path from
     at least one of the treatments.
     """
-    # dpaths = self.get_all_directed_paths(nodes1, nodes2)
-    # return len(dpaths) > 0
     outcome_node_candidates = set()
     action_node_candidates = set()
     for node in nodes1:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3229,8 +3229,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
@@ -5085,8 +5085,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.3", markers = "python_version == \"3.10\" and platform_system == \"Windows\" and platform_python_implementation != \"PyPy\""},
     {version = ">=1.18", markers = "python_version != \"3.10\" or platform_system != \"Windows\" or platform_python_implementation == \"PyPy\""},
+    {version = ">=1.22.3", markers = "python_version == \"3.10\" and platform_system == \"Windows\" and platform_python_implementation != \"PyPy\""},
 ]
 packaging = ">=21.3"
 pandas = ">=1.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3229,8 +3229,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
@@ -5085,8 +5085,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.18", markers = "python_version != \"3.10\" or platform_system != \"Windows\" or platform_python_implementation == \"PyPy\""},
     {version = ">=1.22.3", markers = "python_version == \"3.10\" and platform_system == \"Windows\" and platform_python_implementation != \"PyPy\""},
+    {version = ">=1.18", markers = "python_version != \"3.10\" or platform_system != \"Windows\" or platform_python_implementation == \"PyPy\""},
 ]
 packaging = ">=21.3"
 pandas = ">=1.0"

--- a/tests/causal_identifiers/test_auto_identifier.py
+++ b/tests/causal_identifiers/test_auto_identifier.py
@@ -4,17 +4,14 @@ from dowhy.graph import build_graph_from_str
 
 
 class TestAutoIdentification(object):
-    def test_auto_identify_consistently_checks_for_directed_paths(self):
+    def test_auto_identify_identifies_no_directed_path(self):
+        # Test added for issue #1250
         graph = build_graph_from_str("digraph{T->Y;A->Y;A->B;}")
         identifier = AutoIdentifier(estimand_type=EstimandType.NONPARAMETRIC_ATE)
-        identified_estimand = identifier.identify_effect(
-            graph, action_nodes=["T", "B"], outcome_nodes=["Y"], observed_nodes=["T", "Y", "A", "B"]
-        )
-        identified_estimand_swapped_action_order = identifier.identify_effect(
-            graph, action_nodes=["B", "T"], outcome_nodes=["Y"], observed_nodes=["T", "Y", "A", "B"]
-        )
-        backdoor_vars = identified_estimand.get_backdoor_variables()
-        backdoor_vars_swapped_action_order = identified_estimand_swapped_action_order.get_backdoor_variables()
 
-        assert len(backdoor_vars) == 0
-        assert len(backdoor_vars_swapped_action_order) == 0
+        assert identifier.identify_effect(
+            graph, action_nodes=["T", "B"], outcome_nodes=["Y"], observed_nodes=["T", "Y", "A", "B"]
+        ).no_directed_path
+        assert identifier.identify_effect(
+            graph, action_nodes=["B", "T"], outcome_nodes=["Y"], observed_nodes=["T", "Y", "A", "B"]
+        ).no_directed_path

--- a/tests/causal_identifiers/test_auto_identifier.py
+++ b/tests/causal_identifiers/test_auto_identifier.py
@@ -1,0 +1,29 @@
+from dowhy.causal_identifier import AutoIdentifier
+from dowhy.causal_identifier.identify_effect import EstimandType
+from dowhy.graph import build_graph_from_str
+
+
+class TestAutoIdentification(object):
+    def test_auto_identify_consistently_checks_for_directed_paths(self):
+        graph = build_graph_from_str("digraph{T->Y;A->Y;A->B;}")
+        identifier = AutoIdentifier(
+            estimand_type=EstimandType.NONPARAMETRIC_ATE
+        )
+        identified_estimand = identifier.identify_effect(
+            graph,
+            action_nodes=["T", "B"],
+            outcome_nodes=["Y"],
+            observed_nodes=["T", "Y", "A", "B"]
+        )
+        identified_estimand_swapped_action_order = identifier.identify_effect(
+            graph,
+            action_nodes=["B", "T"],
+            outcome_nodes=["Y"],
+            observed_nodes=["T", "Y", "A", "B"]
+        )
+        backdoor_vars = identified_estimand.get_backdoor_variables()
+        backdoor_vars_swapped_action_order = identified_estimand_swapped_action_order.get_backdoor_variables()
+
+        assert len(backdoor_vars) == 0
+        assert len(backdoor_vars_swapped_action_order) == 0
+

--- a/tests/causal_identifiers/test_auto_identifier.py
+++ b/tests/causal_identifiers/test_auto_identifier.py
@@ -6,24 +6,15 @@ from dowhy.graph import build_graph_from_str
 class TestAutoIdentification(object):
     def test_auto_identify_consistently_checks_for_directed_paths(self):
         graph = build_graph_from_str("digraph{T->Y;A->Y;A->B;}")
-        identifier = AutoIdentifier(
-            estimand_type=EstimandType.NONPARAMETRIC_ATE
-        )
+        identifier = AutoIdentifier(estimand_type=EstimandType.NONPARAMETRIC_ATE)
         identified_estimand = identifier.identify_effect(
-            graph,
-            action_nodes=["T", "B"],
-            outcome_nodes=["Y"],
-            observed_nodes=["T", "Y", "A", "B"]
+            graph, action_nodes=["T", "B"], outcome_nodes=["Y"], observed_nodes=["T", "Y", "A", "B"]
         )
         identified_estimand_swapped_action_order = identifier.identify_effect(
-            graph,
-            action_nodes=["B", "T"],
-            outcome_nodes=["Y"],
-            observed_nodes=["T", "Y", "A", "B"]
+            graph, action_nodes=["B", "T"], outcome_nodes=["Y"], observed_nodes=["T", "Y", "A", "B"]
         )
         backdoor_vars = identified_estimand.get_backdoor_variables()
         backdoor_vars_swapped_action_order = identified_estimand_swapped_action_order.get_backdoor_variables()
 
         assert len(backdoor_vars) == 0
         assert len(backdoor_vars_swapped_action_order) == 0
-

--- a/tests/causal_identifiers/test_efficient_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_efficient_backdoor_identifier.py
@@ -104,7 +104,7 @@ def test_fail_multivar_outcome_efficient_backdoor_algorithms():
         ident_eff.identify_effect(
             build_graph_from_str(example["graph_str"]),
             observed_nodes=example["observed_node_names"],
-            action_nodes=["X"],
-            outcome_nodes=["Y", "R"],
+            action_nodes=["U"],
+            outcome_nodes=["Y", "F"],
             conditional_node_names=example["conditional_node_names"],
         )

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -123,4 +123,5 @@ class TestCausalGraph(object):
     def test_has_path(self):
         assert has_directed_path(self.nx_graph, ["X0"], ["y"])
         assert has_directed_path(self.nx_graph, ["X0", "X1", "X2"], ["y", "v0"])
+        assert not has_directed_path(self.nx_graph, [], ["y"])
         assert not has_directed_path(self.nx_graph, ["X0", "X1", "X2"], ["y", "v0", "Z0"])

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -119,3 +119,8 @@ class TestCausalGraph(object):
     def test_build_graph_from_str(self):
         build_graph_from_str(self.daggity_file)
         build_graph_from_str(self.graph_str)
+
+    def test_has_path(self):
+        assert has_directed_path(self.nx_graph, ["X0"], ["y"])
+        assert has_directed_path(self.nx_graph, ["X0", "X1", "X2"], ["y", "v0"])
+        assert not has_directed_path(self.nx_graph, ["X0", "X1", "X2"], ["y", "v0", "Z0"])


### PR DESCRIPTION
This PR extends the has_directed_path method to accept multiple treatment and outcome nodes. The approach taken here is as recommended from Issue #654:

> (2) more aggressively: every one of the treatments has at least one direct path to one of the outcomes. And, every one of the outcomes has a direct path from at least one of the treatments.

I opted to implement this by computing the list of all nodes reachable from our treatments, plus the list of all nodes that can reach our outcomes, rather than iteratively using networkx's [has_path method](https://networkx.org/documentation/stable/_modules/networkx/algorithms/shortest_paths/generic.html#has_path), since under the hood has_path is computing shortest paths, but we really do not need to incur the additional runtime of computing these shortest paths.

Related Issue: #654 