### PR TITLE
Fix issue #1254: pass the variable 'categorical'

### DIFF
--- a/dowhy/gcm/model_evaluation.py
+++ b/dowhy/gcm/model_evaluation.py
@@ -454,7 +454,7 @@ def _evaluate_model_performances(
                 )
 
                 conditional_expectations = _estimate_conditional_expectations(
-                    tmp_causal_mechanism, parent_data[test_indices], is_categorical, 50
+                    tmp_causal_mechanism, parent_data[test_indices], categorical, 50
                 )
                 if categorical:
                     metric_evaluations["F1"].append(


### PR DESCRIPTION
pass the variable 'categorical' instead of the method 'is_categorical'

Based on the context of the codes, the variable 'categorical' should be passed in the function call of '_estimate_conditional_expectations' instead of the method 'is_categorical'