### PR TITLE
Introducing DoWhy Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|BuildStatus|_ |PyPiVersion|_ |PythonSupport|_ |Downloads|_ |discord|_
+|BuildStatus|_ |PyPiVersion|_ |PythonSupport|_ |Downloads|_ |discord|_ |gurubase|_
 
 .. |PyPiVersion| image:: https://img.shields.io/pypi/v/dowhy.svg
 .. _PyPiVersion: https://pypi.org/project/dowhy/
@@ -14,6 +14,9 @@
 
 .. |discord| image:: https://img.shields.io/discord/818456847551168542
 .. _discord: https://discord.gg/cSBGb3vsZb
+
+.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20DoWhy%20Guru-006BFF
+.. _gurubase: https://gurubase.io/g/dowhy
 
 .. image:: dowhy-logo-large.png
   :width: 50%


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [DoWhy Guru](https://gurubase.io/g/dowhy) to Gurubase. DoWhy Guru uses the data from this repo and data from the [docs](https://www.pywhy.org/dowhy/v0.11.1/) to answer questions by leveraging the LLM.

In this PR, I showcased the "DoWhy Guru" badge, which highlights that DoWhy now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable DoWhy Guru in Gurubase, just let me know that's totally fine.
