### PR TITLE
Change order of navigation entries in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,10 +9,10 @@ DoWhy documentation
     getting_started/index
     User Guide <user_guide/index>
     Examples <example_notebooks/nb_index>
-    dowhy
-    Contributing <contributing>
-    code_repo
     cite
+    Contributing <contributing>
+    dowhy
+    code_repo
 
 **Date**: |today| **Version**: |version|
 


### PR DESCRIPTION
Changing from
"Getting Starte" - "User Guide" - "Examples" - "dowhy package" - "Contributing" - "Release notes" - "Citing this package" to
"Getting Starte" - "User Guide" - "Examples" - "Citing this package" - "Contributing" - "Dowhy package" "Release notes"

Here, the last two entries are now 'hidden' under a "more" tab, i.e., putting the more important information to the front. Source references might be easier to find via the search function.