### PR TITLE
Fix typo error in docs-release workflow

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Prune old doc versions
         run: |
             mkdir -p ./tmp
-            mv ./dowhy_docs/$VERSION ./tmp/$VERSION
+            mv ./dowhy-docs/$VERSION ./tmp/$VERSION
             rm -rf ./dowhy-docs/*
             mv ./tmp/$VERSION ./dowhy-docs/$VERSION
             echo "Assets ready, listing contents..."


### PR DESCRIPTION
v0.12 release: the docs-release had an error. See https://github.com/py-why/dowhy/actions/runs/11994244419