### PR TITLE
Add experimental missing data support for GCM

### DIFF
--- a/dowhy/gcm/fitting_sampling.py
+++ b/dowhy/gcm/fitting_sampling.py
@@ -87,12 +87,14 @@ def fit_causal_model_of_target(
     """
     validate_causal_model_assignment(causal_model.graph, target_node)
 
+    y_nan_mask = pd.isna(training_data[target_node].to_numpy())
+
     if is_root_node(causal_model.graph, target_node):
-        causal_model.causal_mechanism(target_node).fit(X=training_data[target_node].to_numpy())
+        causal_model.causal_mechanism(target_node).fit(X=training_data[target_node].to_numpy()[~y_nan_mask])
     else:
         causal_model.causal_mechanism(target_node).fit(
-            X=training_data[get_ordered_predecessors(causal_model.graph, target_node)].to_numpy(),
-            Y=training_data[target_node].to_numpy(),
+            X=training_data[get_ordered_predecessors(causal_model.graph, target_node)].to_numpy()[~y_nan_mask],
+            Y=training_data[target_node].to_numpy()[~y_nan_mask],
         )
 
     # To be able to validate that the graph structure did not change between fitting and causal query, we store the

--- a/dowhy/gcm/util/general.py
+++ b/dowhy/gcm/util/general.py
@@ -2,6 +2,7 @@ import random
 from typing import Dict, Optional, Union
 
 import numpy as np
+import pandas as pd
 from scipy.optimize import minimize
 from sklearn.preprocessing import OneHotEncoder
 
@@ -160,17 +161,25 @@ def is_categorical(X: np.ndarray) -> bool:
     """
     X = shape_into_2d(X)
 
+    nan_mask = pd.isna(X).any(axis=1)
+
     status = True
     for column in range(X.shape[1]):
-        if (isinstance(X[0, column], int) or isinstance(X[0, column], float)) and np.isnan(X[0, column]):
-            raise ValueError(
-                "Input contains NaN values! This is currently not supported. " "Consider imputing missing values."
-            )
+        X = X[~nan_mask]
+
+        if X.shape[0] == 0:
+            return False
 
         status &= isinstance(X[0, column], str) or isinstance(X[0, column], bool) or isinstance(X[0, column], np.bool_)
 
         if not status:
             break
+
+    if status and nan_mask.any():
+        raise ValueError(
+            "The target variable appears to be categorical and has missing data. Currently, only missing "
+            "data for numerical variables is supported! Consider treating the missing category separately"
+        )
 
     return status
 


### PR DESCRIPTION
The current implementation has the following limits:
- Only missing data in numerical features are supported
- Auto assignment only considers non-linear models for missing data
- Auto assignment only considers 3 different model types
- Not all GCM methods are supported. For example, distribution change based on missing data does not work due to the independence tests.
- Not tested thoroughly

To use the data with missing values, experimental_allow_nans has to be set to True in the assign_causal_mechanisms method. Manual model assignment should work as well.

Addresses: https://github.com/py-why/dowhy/issues/1300