### PR TITLE
Replace warn with warning

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -250,7 +250,7 @@ class CausalEstimator:
         # Making sure that effect_modifier_names is a list
         effect_modifier_names = parse_state(effect_modifier_names)
         if not all(em in self._effect_modifier_names for em in effect_modifier_names):
-            self.logger.warn(
+            self.logger.warning(
                 "At least one of the provided effect modifiers was not included while fitting the estimator. You may get incorrect results. To resolve, fit the estimator again by providing the updated effect modifiers in estimate_effect()."
             )
         # Making a copy since we are going to be changing effect modifier names

--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -134,7 +134,7 @@ class Econml(CausalEstimator):
                 effect_modifier_names = self._effect_modifier_names.copy()
             w_diff_x = [w for w in self._observed_common_causes_names if w not in effect_modifier_names]
             if len(w_diff_x) > 0:
-                self.logger.warn(
+                self.logger.warning(
                     "Concatenating common_causes and effect_modifiers and providing a single list of variables to metalearner estimator method, "
                     + self.estimator.__class__.__name__
                     + ". EconML metalearners accept a single X argument."

--- a/dowhy/causal_identifier/auto_identifier.py
+++ b/dowhy/causal_identifier/auto_identifier.py
@@ -186,7 +186,7 @@ def identify_effect_auto(
 
     # First, check if there is a directed path from action to outcome
     if not has_directed_path(graph, action_nodes, outcome_nodes):
-        logger.warn("No directed path from treatment to outcome. Causal Effect is zero.")
+        logger.warning("No directed path from treatment to outcome. Causal Effect is zero.")
         return IdentifiedEstimand(
             None,
             treatment_variable=action_nodes,

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -583,7 +583,7 @@ def _warn_if_unobserved_graph_variables(
             "unobserved because they are not in the dataset. "
             "Configure the logging level to `logging.WARNING` or higher for additional details."
         )
-        logger.warn(
+        logger.warning(
             "The graph defines %d variables. %d were found in the dataset "
             "and will be analyzed as observed variables. %d were not found "
             "in the dataset and will be analyzed as unobserved variables. "
@@ -609,7 +609,7 @@ def _warn_if_unused_data_variables(
     unused_data_variable_names = data_variable_names.difference(graph_variable_names)
 
     if unused_data_variable_names:
-        logger.warn(
+        logger.warning(
             "There are an additional %d variables in the dataset that are "
             "not in the graph. Variable names are: '%s'",
             len(unused_data_variable_names),

--- a/dowhy/causal_refuters/graph_refuter.py
+++ b/dowhy/causal_refuters/graph_refuter.py
@@ -39,7 +39,7 @@ class GraphRefuter(CausalRefuter):
             self._refutation_passed = True
         elif len(self._false_implications) == 0:
             self._refutation_passed = True
-            self.logger.warn("Some tests could not be run : config not supported")
+            self.logger.warning("Some tests could not be run : config not supported")
         elif len(self._false_implications) > 0:
             self._refutation_passed = False
 


### PR DESCRIPTION
The `warn` method of logger is deprecated and warns user to use the `warning` method instead.

Sorry, do you have pre-commit for the formatting style? 