### PR TITLE
Correct vertical stacking in linearity check

### DIFF
--- a/dowhy/gcm/auto.py
+++ b/dowhy/gcm/auto.py
@@ -473,8 +473,8 @@ def has_linear_relationship(X: np.ndarray, Y: np.ndarray, max_num_samples: int =
         for i in range(all_classes.size):
             # Making sure that there are at least 2 samples from one class (here, simply duplicate the point).
             if counts[i] == 1:
-                X = np.row_stack([X, X[indices[i], :]])
-                Y = np.row_stack([Y, Y[indices[i], :]])
+                X = np.vstack([X, X[indices[i], :]])
+                Y = np.vstack([Y, Y[indices[i], :]])
 
         x_train, x_test, y_train, y_test = train_test_split(
             X, Y, train_size=num_trainings_samples, test_size=num_test_samples, stratify=Y


### PR DESCRIPTION
# PR Summary
This PR modernizes NumPy array stacking by replacing deprecated aliases. It solves the following warnings which you can find in the [CI logs](https://github.com/py-why/dowhy/actions/runs/16490824292/job/46624862289#step:11:184): 
```python
DeprecationWarning: `row_stack` alias is deprecated. Use `np.vstack` directly.
```