### PR TITLE
Fix CUDA errors in conditional regularizer

### DIFF
--- a/dowhy/causal_prediction/algorithms/regularization.py
+++ b/dowhy/causal_prediction/algorithms/regularization.py
@@ -143,9 +143,10 @@ class Regularizer:
                     cardinality = 1 + torch.max(grouping_data, dim=0)[0]
                     cumprod = torch.cumprod(cardinality, dim=0)
                     n_groups = cumprod[-1].item()
-                    factors_np = np.concatenate(([1], cumprod[:-1]))
-                    factors = torch.from_numpy(factors_np)
-                    group_indices = grouping_data @ factors
+                    factors = torch.cat(
+                            (torch.tensor([1], dtype=cumprod.dtype, device=cumprod.device), cumprod[:-1])
+                    )
+                    group_indices = (grouping_data.float() @ factors.float()).long()
 
                     for group_idx in range(n_groups):
                         group_idx_indices = [
@@ -206,9 +207,10 @@ class Regularizer:
                     cardinality = 1 + torch.max(grouping_data, dim=0)[0]
                     cumprod = torch.cumprod(cardinality, dim=0)
                     n_groups = cumprod[-1].item()
-                    factors_np = np.concatenate(([1], cumprod[:-1]))
-                    factors = torch.from_numpy(factors_np)
-                    group_indices = grouping_data @ factors
+                    factors = torch.cat(
+                            (torch.tensor([1], dtype=cumprod.dtype, device=cumprod.device), cumprod[:-1])
+                    )
+                    group_indices = (grouping_data.float() @ factors.float()).long()
 
                     for group_idx in range(n_groups):
                         group_idx_indices = [
@@ -246,9 +248,10 @@ class Regularizer:
                     cardinality = 1 + torch.max(grouping_data, dim=0)[0]
                     cumprod = torch.cumprod(cardinality, dim=0)
                     n_groups = cumprod[-1].item()
-                    factors_np = np.concatenate(([1], cumprod[:-1]))
-                    factors = torch.from_numpy(factors_np)
-                    group_indices = grouping_data @ factors
+                    factors = torch.cat(
+                            (torch.tensor([1], dtype=cumprod.dtype, device=cumprod.device), cumprod[:-1])
+                    )
+                    group_indices = (grouping_data.float() @ factors.float()).long()
 
                     for group_idx in range(n_groups):
                         group_idx_indices = [


### PR DESCRIPTION
This pull request resolves issue #1306 by fixing two distinct CUDA-related errors that occur within the `conditional_reg` method in `dowhy/causal_prediction/algorithms/regularizer.py`.

The original implementation of the group index calculation runs correctly on CPU-only but fails on CUDA-enabled environments due to two main reasons:

1.  **Device Mismatch with NumPy:** The code attempted to use `np.concatenate` on `cumprod[:-1]`, which is a CUDA tensor when running on a GPU. This raises a `TypeError` as NumPy functions cannot operate directly on GPU tensors.
2.  **Unsupported Matrix Multiplication Type:** The matrix multiplication (`@` operator) for calculating `group_indices` involved two `LongTensor`s. This triggers a `RuntimeError: "addmv_impl_cuda" not implemented for 'Long'` because the CUDA kernel for this operation expects floating-point types.


To make the function fully device-agnostic and resolve these errors, this PR introduces the following changes:

*   **Replaced NumPy with Pure PyTorch:** The `np.concatenate` call has been replaced with `torch.cat`. A new `torch.tensor([1])` is created on the same device and with the same `dtype` as the `cumprod` tensor, ensuring the entire operation remains on the target device (CPU or GPU) without data transfer.
*   **Corrected Matmul DType:** Before the matrix multiplication, both `grouping_data` and the `factors` tensor are cast to `.float()`. The result is then cast back to `.long()` to be used as indices. This satisfies the CUDA kernel's requirement and fixes the `addmv_impl_cuda` error.

These changes ensure that the regularization logic functions identically and efficiently on both CPU and CUDA devices. I've tested on my CPU-only/2080s/3090 environments.