### PR TITLE
Enabling install using uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "dowhy"
+dynamic = ["version"]
 
 [project.license]
 text = "MIT"


### PR DESCRIPTION
Fixes #1337 by adding a dynamic version field.
Follows the guidance from https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#version