### PR TITLE
Change attribute_anomalies to only use relevant subraph

### DIFF
--- a/dowhy/gcm/anomaly.py
+++ b/dowhy/gcm/anomaly.py
@@ -13,7 +13,7 @@ from dowhy.gcm.causal_models import InvertibleStructuralCausalModel, Probabilist
 from dowhy.gcm.shapley import ShapleyConfig, estimate_shapley_values
 from dowhy.gcm.stats import permute_features
 from dowhy.gcm.util.general import shape_into_2d
-from dowhy.graph import get_ordered_predecessors, is_root_node
+from dowhy.graph import get_ordered_predecessors, is_root_node, node_connected_subgraph_view
 
 
 def conditional_anomaly_scores(
@@ -130,6 +130,7 @@ def attribute_anomalies(
              for the i-th observation in anomaly_samples.
     """
     validate_causal_dag(causal_model.graph)
+    causal_model = InvertibleStructuralCausalModel(node_connected_subgraph_view(causal_model.graph, target_node))
 
     if anomaly_scorer is None:
         anomaly_scorer = MedianCDFQuantileScorer()

--- a/tests/gcm/test_auto.py
+++ b/tests/gcm/test_auto.py
@@ -209,7 +209,9 @@ def test_given_linear_classification_problem_when_auto_assign_causal_models_with
     data.update({"Y": Y})
 
     assign_causal_mechanisms(causal_model, pd.DataFrame(data), quality=AssignmentQuality.BETTER)
-    assert isinstance(causal_model.causal_mechanism("Y").classifier_model.sklearn_model, LogisticRegression)
+    assert isinstance(
+        causal_model.causal_mechanism("Y").classifier_model.sklearn_model, LogisticRegression
+    ) or isinstance(causal_model.causal_mechanism("Y").classifier_model.sklearn_model, Pipeline)
 
 
 @flaky(max_runs=3)


### PR DESCRIPTION
When attributing anomalies to a target node, we can ignore downstream effects of the target.

Addresses: https://github.com/py-why/dowhy/issues/1364