### PR TITLE
Fix #1427: [Repo Assist] ci: pin KyleMayes/install-llvm-action to v2....

### DIFF
--- a/.github/workflows/advanced-on-demand.yml
+++ b/.github/workflows/advanced-on-demand.yml
@@ -56,7 +56,7 @@ jobs:
 
       # At the moment needed to support scipy in Python 3.12
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.5
         with:
           version: "14.0"
           directory: ${{ runner.temp }}/llvm

--- a/.github/workflows/ci-install.yml
+++ b/.github/workflows/ci-install.yml
@@ -38,7 +38,7 @@ jobs:
 
     # At the moment needed to support scipy in Python 3.12+
     - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@v2
+      uses: KyleMayes/install-llvm-action@v2.0.5
       with:
         version: "14.0"
         directory: ${{ runner.temp }}/llvm

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       # At the moment needed to support scipy in Python 3.12+
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.5
         with:
           version: "14.0"
           directory: ${{ runner.temp }}/llvm


### PR DESCRIPTION
Closes #1427

Standardises `KyleMayes/install-llvm-action` to the pinned `@v2.0.5` tag across all three workflows that were using the floating `@v2` reference.

## Changes

- `.github/workflows/advanced-on-demand.yml` line 59: `@v2` → `@v2.0.5`
- `.github/workflows/ci-install.yml` line 41: `@v2` → `@v2.0.5`
- `.github/workflows/nightly-tests.yml` line 32: `@v2` → `@v2.0.5`

`ci.yml` was already pinned to `@v2.0.5` and is unchanged.

## Motivation

Floating major-version tags (e.g. `@v2`) move when the upstream author pushes new releases. If `KyleMayes/install-llvm-action@v2` advances to a version with any incompatibility, the nightly, install-check, and advanced-on-demand workflows would break unexpectedly and non-deterministically. Pinning to `@v2.0.5` makes all four workflows consistent with each other, ensures reproducible builds, and aligns with the convention already established in `ci.yml`.

## Testing

CI configuration change only — no source code or test logic modified. The pinned `@v2.0.5` version is identical to what `ci.yml` currently resolves at runtime under `@v2`, so workflow behaviour is unchanged. Verification: confirm the three affected workflows complete their "Install LLVM and Clang" step successfully on the next triggered run.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*