### PR TITLE
fix: raise ValueError when no valid estimand is identified instead of silent None return

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -744,11 +744,10 @@ def estimate_effect(
         )
     # Check if estimator's target estimand is identified
     elif identified_estimand.estimands[identifier_name] is None:
-        logger.error("No valid identified estimand available.")
-        return CausalEstimate(
-            None, None, None, None, None, None, control_value=control_value, treatment_value=treatment_value
-        )
-
+        error_msg = f"No valid identified estimand available for identifier '{identifier_name}'. Ensure the graph supports this identification method."
+        logger.error(error_msg)
+        raise ValueError(error_msg)
+        
     if fit_estimator:
         estimator.fit(
             data=data,

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -744,10 +744,10 @@ def estimate_effect(
         )
     # Check if estimator's target estimand is identified
     elif identified_estimand.estimands[identifier_name] is None:
-        error_msg = f"No valid identified estimand available for identifier '{identifier_name}'. Ensure the graph supports this identification method."
+        error_msg = f"No valid identified estimand for '{identifier_name}'. Ensure that the identification step succeeded for this estimator method (e.g. the graph must contain valid instruments for 'iv.instrumental_variable')."
         logger.error(error_msg)
         raise ValueError(error_msg)
-        
+
     if fit_estimator:
         estimator.fit(
             data=data,

--- a/tests/test_causal_estimator.py
+++ b/tests/test_causal_estimator.py
@@ -67,7 +67,7 @@ def test_estimate_effect_raises_valueerror_for_missing_estimand():
         graph=data["dot_graph"],
     )
     estimand = model.identify_effect(proceed_when_unidentifiable=True)
-    with pytest.raises(ValueError, match="No valid identified estimand available"):
+    with pytest.raises(ValueError, match=r"No valid identified estimand for 'iv'"):
         model.estimate_effect(
             identified_estimand=estimand,
             method_name="iv.instrumental_variable",

--- a/tests/test_causal_estimator.py
+++ b/tests/test_causal_estimator.py
@@ -42,3 +42,33 @@ class TestCausalEstimator(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_estimate_effect_raises_valueerror_for_missing_estimand():
+    """estimate_effect() must raise ValueError when no valid estimand is identified.
+
+    Previously, it silently returned None, giving users no indication of failure.
+    See issue #1551 https://github.com/py-why/dowhy/issues/1551
+    """
+    import dowhy.datasets
+    from dowhy import CausalModel
+
+    data = dowhy.datasets.linear_dataset(
+        beta=10,
+        num_common_causes=3,
+        num_instruments=0,
+        num_samples=500,
+        treatment_is_binary=True,
+    )
+    model = CausalModel(
+        data=data["df"],
+        treatment=data["treatment_name"],
+        outcome=data["outcome_name"],
+        graph=data["dot_graph"],
+    )
+    estimand = model.identify_effect(proceed_when_unidentifiable=True)
+    with pytest.raises(ValueError, match="No valid identified estimand available"):
+        model.estimate_effect(
+            identified_estimand=estimand,
+            method_name="iv.instrumental_variable",
+        )


### PR DESCRIPTION
### Summary
`estimate_effect()` silently returns `None` when `identified_estimand.estimands[identifier_name]` is `None`, logging an error but not raising. Users get no indication that identification failed.

### Fix
Replace the silent `return CausalEstimate(None, ...)` with `raise ValueError(error_msg)` including the identifier name for easier debugging.

### Impact
- callers now get a clear `ValueError` instead of silent `None`
- error message includes the identifier name to help users debug their graph or method choice
- adds a regression test to prevent future recurrence

Fixes #1551
Signed-off-by: abhiprd2000