### PR TITLE
Add random_state to AddUnobservedCommonCause for reproducible simulation refutation

### DIFF
--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -70,6 +70,7 @@ class AddUnobservedCommonCause(CausalRefuter):
         :param num_splits: number of splits for cross validation. (default = 5). (relevant only for non-parametric-partial-R2 simulation method)
         :param shuffle_data : shuffle data or not before splitting into folds (default = False). (relevant only for non-parametric-partial-R2 simulation method)
         :param shuffle_random_seed: seed for randomly shuffling data. (relevant only for non-parametric-partial-R2 simulation method)
+        :param random_state: int or numpy.random.RandomState used to make the simulated confounder reproducible. If None (default), results vary between runs. (relevant only for direct-simulation method)
         :param alpha_s_estimator_param_list: list of dictionaries with parameters for finding alpha_s. (relevant only for non-parametric-partial-R2 simulation method)
         :param g_s_estimator_list: list of estimator objects for finding g_s. These objects should have fit() and predict() functions implemented. (relevant only for non-parametric-partial-R2 simulation method)
         :param g_s_estimator_param_list: list of dictionaries with parameters for tuning respective estimators in "g_s_estimator_list". The order of the dictionaries in the list should be consistent with the estimator objects order in "g_s_estimator_list". (relevant only for non-parametric-partial-R2 simulation method)
@@ -121,6 +122,7 @@ class AddUnobservedCommonCause(CausalRefuter):
         self.num_splits = kwargs["num_splits"] if "num_splits" in kwargs else 5
         self.shuffle_data = kwargs["shuffle_data"] if "shuffle_data" in kwargs else False
         self.shuffle_random_seed = kwargs["shuffle_random_seed"] if "shuffle_random_seed" in kwargs else None
+        self._random_state = kwargs["random_state"] if "random_state" in kwargs else None
         self.alpha_s_estimator_param_list = (
             kwargs["alpha_s_estimator_param_list"] if "alpha_s_estimator_param_list" in kwargs else None
         )
@@ -187,6 +189,7 @@ class AddUnobservedCommonCause(CausalRefuter):
                 show_progress_bar,
                 self._n_jobs,
                 self._verbose,
+                self._random_state,
             )
             refute.add_refuter(self)
             return refute
@@ -203,6 +206,7 @@ class AddUnobservedCommonCause(CausalRefuter):
             self._variables_of_interest,
             convergence_threshold,
             c_star_max,
+            self._random_state,
         )
 
 
@@ -348,6 +352,7 @@ def _include_confounders_effect(
     effect_on_y: str,
     outcome_name: str,
     kappa_y: float,
+    random_state: Optional[np.random.RandomState] = None,
 ):
     """
     This function deals with the change in the value of the data due to the effect of the unobserved confounder.
@@ -362,7 +367,7 @@ def _include_confounders_effect(
     """
     num_rows = data.shape[0]
     stdnorm = scipy.stats.norm()
-    w_random = stdnorm.rvs(num_rows)
+    w_random = stdnorm.rvs(num_rows, random_state=random_state)
 
     if effect_on_t == "binary_flip":
         alpha = 2 * kappa_t - 1 if kappa_t >= 0.5 else 1 - 2 * kappa_t
@@ -417,6 +422,7 @@ def include_simulated_confounder(
     variables_of_interest: List,
     convergence_threshold: float = DEFAULT_CONVERGENCE_THRESHOLD,
     c_star_max: int = DEFAULT_C_STAR_MAX,
+    random_state: Optional[Union[int, np.random.RandomState]] = None,
 ):
     """
     This function simulates an unobserved confounder based on the data using the following steps:
@@ -444,11 +450,16 @@ def include_simulated_confounder(
         :type int
     :param convergence_threshold: The threshold to check the plateauing of the correlation while selecting a c_star. It defaults to 0.1 in the code if not specified by the user
         :type float
+    :param random_state: int or numpy.random.RandomState used to make the simulated confounder reproducible. If None (default), results vary between runs.
+        :type int, RandomState, optional
 
     :returns: The simulated values of the unobserved confounder based on the data
         :type pandas.core.series.Series
 
     """
+
+    if isinstance(random_state, int):
+        random_state = np.random.RandomState(seed=random_state)
 
     # Obtaining the list of observed variables
     required_variables = True
@@ -509,7 +520,7 @@ def include_simulated_confounder(
     for i in range(0, int(c_star_max), step):
         c1 = math.sqrt(i)
         c2 = c1
-        final_U = _generate_confounder_from_residuals(c1, c2, d_y, d_t, X)
+        final_U = _generate_confounder_from_residuals(c1, c2, d_y, d_t, X, random_state=random_state)
         current_simulated_confounder = final_U
         outcome_values = data[outcome_name[0]]
         correlation_y = current_simulated_confounder.corr(outcome_values)
@@ -548,7 +559,7 @@ def include_simulated_confounder(
     while i <= threshold:
         c2 = i
         c1 = c_star / c2
-        final_U = _generate_confounder_from_residuals(c1, c2, d_y, d_t, X)
+        final_U = _generate_confounder_from_residuals(c1, c2, d_y, d_t, X, random_state=random_state)
 
         current_simulated_confounder = final_U
         outcome_values = data[outcome_name[0]]
@@ -583,12 +594,12 @@ def include_simulated_confounder(
         c2 = math.sqrt(c_star_max/additional_condition)
         c1 = c_star_max/c2"""
 
-    final_U = _generate_confounder_from_residuals(c1_final, c2_final, d_y, d_t, X)
+    final_U = _generate_confounder_from_residuals(c1_final, c2_final, d_y, d_t, X, random_state=random_state)
 
     return final_U
 
 
-def _generate_confounder_from_residuals(c1, c2, d_y, d_t, X):
+def _generate_confounder_from_residuals(c1, c2, d_y, d_t, X, random_state: Optional[np.random.RandomState] = None):
     """
     This function takes the residuals from the treatment and outcome model and their coefficients and simulates the intermediate random variable U by taking
     the row wise normal distribution corresponding to each residual value and then debiasing the intermediate variable to get the final variable.
@@ -606,12 +617,14 @@ def _generate_confounder_from_residuals(c1, c2, d_y, d_t, X):
     :type pandas.core.series.Series
 
     """
+    rng = np.random if random_state is None else random_state
+
     U = []
 
     for j in range(len(d_t)):
         simulated_variable_mean = c1 * d_y[j] + c2 * d_t[j]
         simulated_variable_stddev = 1
-        U.append(np.random.normal(simulated_variable_mean, simulated_variable_stddev, 1))
+        U.append(rng.normal(simulated_variable_mean, simulated_variable_stddev, 1))
 
     U = np.array(U)
     model = sm.OLS(U, X)
@@ -796,6 +809,7 @@ def _simulate_confounders_effect_once(
     confounders_effect_on_outcome: str,
     kappa_t_value: float,
     kappa_y_value: float,
+    random_state: Optional[np.random.RandomState] = None,
 ) -> float:
     """Execute one simulation with specific kappa_t and kappa_y values."""
     new_data = _include_confounders_effect(
@@ -807,6 +821,7 @@ def _simulate_confounders_effect_once(
         confounders_effect_on_outcome,
         outcome_name,
         kappa_y_value,
+        random_state=random_state,
     )
     new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
     new_estimator.fit(
@@ -839,6 +854,7 @@ def sensitivity_simulation(
     show_progress_bar=False,
     n_jobs: int = 1,
     verbose: int = 0,
+    random_state: Optional[Union[int, np.random.RandomState]] = None,
     **_,
 ) -> CausalRefutation:
     """
@@ -858,6 +874,7 @@ def sensitivity_simulation(
     :param frac_strength_treatment: float: This parameter decides the effect strength of the simulated confounder as a fraction of the effect strength of observed confounders on treatment. Defaults to 1.
     :param frac_strength_outcome: float: This parameter decides the effect strength of the simulated confounder as a fraction of the effect strength of observed confounders on outcome. Defaults to 1.
     :param plotmethod: string: Type of plot to be shown. If None, no plot is generated. This parameter is used only only when more than one treatment confounder effect values or outcome confounder effect values are provided. Default is "colormesh". Supported values are "contour", "colormesh" when more than one value is provided for both confounder effect value parameters; "line" when provided for only one of them.
+    :param random_state: int or numpy.random.RandomState used to make the simulated confounder reproducible. If None (default), results vary between runs.
 
     :return: CausalRefuter: An object that contains the estimated effect and a new effect and the name of the refutation used.
     """
@@ -869,6 +886,9 @@ def sensitivity_simulation(
         kappa_y = _infer_default_kappa_y(
             data, target_estimand, outcome_name, confounders_effect_on_outcome, frac_strength_outcome
         )
+
+    if isinstance(random_state, int):
+        random_state = np.random.RandomState(seed=random_state)
 
     if not isinstance(kappa_t, (list, np.ndarray)) and not isinstance(
         kappa_y, (list, np.ndarray)
@@ -883,6 +903,7 @@ def sensitivity_simulation(
             confounders_effect_on_outcome,
             outcome_name,
             kappa_y,
+            random_state=random_state,
         )
         new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
         new_estimator.fit(
@@ -933,6 +954,7 @@ def sensitivity_simulation(
                     confounders_effect_on_outcome,
                     kappa_t_val,
                     kappa_y_val,
+                    random_state,
                 )
                 for i, j, kappa_t_val, kappa_y_val in tqdm(
                     param_combinations,
@@ -989,7 +1011,7 @@ def sensitivity_simulation(
             return refute
 
         elif isinstance(kappa_t, (list, np.ndarray)):
-            outcomes = np.random.rand(len(kappa_t))
+            outcomes = np.zeros(len(kappa_t))
             orig_data = copy.deepcopy(data)
 
             for i in tqdm(
@@ -1007,6 +1029,7 @@ def sensitivity_simulation(
                     confounders_effect_on_outcome,
                     outcome_name,
                     kappa_y,
+                    random_state=random_state,
                 )
                 new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
                 new_estimator.fit(
@@ -1047,7 +1070,7 @@ def sensitivity_simulation(
             return refute
 
         elif isinstance(kappa_y, (list, np.ndarray)):
-            outcomes = np.random.rand(len(kappa_y))
+            outcomes = np.zeros(len(kappa_y))
             orig_data = copy.deepcopy(data)
 
             for i in tqdm(
@@ -1065,6 +1088,7 @@ def sensitivity_simulation(
                     confounders_effect_on_outcome,
                     outcome_name,
                     kappa_y[i],
+                    random_state=random_state,
                 )
                 new_estimator = estimate.estimator.get_new_estimator_object(target_estimand)
                 new_estimator.fit(

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -628,3 +628,41 @@ class TestAddUnobservedCommonCauseRefuter(object):
             simulation_method="direct-simulation",
         )
         assert refute is not None
+
+
+def _make_unobserved_refuter_model():
+    import pandas as pd
+
+    rng = np.random.RandomState(0)
+    n = 500
+    w = rng.normal(size=n)
+    v = (rng.uniform(size=n) < 1 / (1 + np.exp(-w))).astype(int)
+    y = 2 * v + w + rng.normal(size=n)
+    df = pd.DataFrame({"v0": v, "W0": w, "y": y})
+    model = CausalModel(data=df, treatment="v0", outcome="y", common_causes=["W0"])
+    identified_estimand = model.identify_effect()
+    estimate = model.estimate_effect(identified_estimand, method_name="backdoor.propensity_score_weighting")
+    return model, identified_estimand, estimate
+
+
+def _run_unobserved_refuter(random_state):
+    model, identified_estimand, estimate = _make_unobserved_refuter_model()
+    refute = model.refute_estimate(
+        identified_estimand,
+        estimate,
+        method_name="add_unobserved_common_cause",
+        confounders_effect_on_treatment="binary_flip",
+        confounders_effect_on_outcome="linear",
+        effect_strength_on_treatment=0.01,
+        effect_strength_on_outcome=0.02,
+        random_state=random_state,
+    )
+    return refute.new_effect
+
+
+def test_add_unobserved_common_cause_is_reproducible_with_random_state():
+    assert _run_unobserved_refuter(random_state=123) == _run_unobserved_refuter(random_state=123)
+
+
+def test_add_unobserved_common_cause_differs_across_random_states():
+    assert _run_unobserved_refuter(random_state=123) != _run_unobserved_refuter(random_state=456)


### PR DESCRIPTION
Part of making DoWhy's refutation results reproducible (follow-up to #1556 and #1557; related: #556, #418).

## What
The `add_unobserved_common_cause` refuter is non-deterministic and can't be seeded. In the `direct-simulation` path, `_include_confounders_effect` draws `w_random = stdnorm.rvs(num_rows)` with no `random_state`, so each run produces a different simulated confounder and a different refutation result. The residuals-based `include_simulated_confounder` path has the same issue via `np.random.normal`.

The class only exposes `shuffle_random_seed`, which applies solely to the non-parametric-partial-R2 path — there's no way to make the simulation-based refutation reproducible.

## Changes
- Add a `random_state` parameter (`int` or `np.random.RandomState`, default `None`) to `AddUnobservedCommonCause` and thread it through `sensitivity_simulation` → `_simulate_confounders_effect_once` → `_include_confounders_effect` (into `stdnorm.rvs`), and through `include_simulated_confounder` → `_generate_confounder_from_residuals` (into the normal draw).
- Convert int seeds to a `np.random.RandomState` once and pass the instance through, matching the convention already used by `RandomCommonCause`.
- `random_state=None` preserves the existing (non-deterministic) behavior, so this is backward compatible.
- Minor: the two `outcomes = np.random.rand(len(...))` lines were only pre-allocating an array that's immediately overwritten in the loop; replaced with `np.zeros(...)` to avoid an unnecessary RNG draw.
- Add regression tests asserting same-seed runs are identical and different-seed runs differ.

## Usage
```python
refute = model.refute_estimate(
    identified_estimand,
    estimate,
    method_name="add_unobserved_common_cause",
    confounders_effect_on_treatment="binary_flip",
    confounders_effect_on_outcome="linear",
    effect_strength_on_treatment=0.01,
    effect_strength_on_outcome=0.02,
    random_state=42,
)
```

## Verification
- Same seed → identical `new_effect`; different seeds → different; default path unchanged and still non-deterministic.
- New tests in `tests/causal_refuters/test_add_unobserved_common_cause.py` pass; black/isort clean.