### PR TITLE
fix: wrap one_hot_encode execution blocks to catch nested structure failures

### DIFF
--- a/dowhy/utils/encoding.py
+++ b/dowhy/utils/encoding.py
@@ -22,7 +22,6 @@ def one_hot_encode(data: pd.DataFrame, columns=None, drop_first: bool = False, e
     :return: DataFrame, OneHotEncoder
     """
 
-    # Determine columns being encoded
     if columns is None:
         dtypes_to_encode = ["object", "string", "category"]
         data_to_encode = data.select_dtypes(include=dtypes_to_encode)
@@ -31,32 +30,39 @@ def one_hot_encode(data: pd.DataFrame, columns=None, drop_first: bool = False, e
     else:
         data_to_encode = data[columns]
 
-    # If all columns are already numerical, there may be nothing to encode.
-    # In this case, return original data.
     if len(data_to_encode.columns) == 0:
-        return data, encoder  # Encoder may be None
+        return data, encoder
 
     # Columns to keep in the result - not encoded.
     columns_to_keep = data.columns.difference(data_to_encode.columns)
     df_columns_to_keep = data[columns_to_keep].reset_index(drop=True)
 
-    if encoder is None:  # Create new encoder
-        drop = None
-        if drop_first:
-            drop = "first"
-        encoder = OneHotEncoder(drop=drop, sparse_output=False)  # NB sparse renamed to sparse_output in sklearn 1.2+
+    try:
+        if encoder is None:  # Create new encoder
+            drop = None
+            if drop_first:
+                drop = "first"
+            encoder = OneHotEncoder(
+                drop=drop, sparse_output=False
+            )  # NB sparse renamed to sparse_output in sklearn 1.2+
 
-        encoded_data = encoder.fit_transform(data_to_encode)
+            encoded_data = encoder.fit_transform(data_to_encode)
 
-    else:  # Use existing encoder
-        encoded_data = encoder.transform(data_to_encode)
+        else:  # Use existing encoder
+            encoded_data = encoder.transform(data_to_encode)
 
-    # Convert the encoded data to a DataFrame
+    except Exception as e:
+        raise TypeError(
+            f"DoWhy's categorical encoding failed during one-hot conversion. This typically happens "
+            f"when columns selected for encoding contain complex, nested, mixed, or unhashable data structures "
+            f"(such as dicts, lists, sets, unaligned tuples, or enums) that the underlying encoder cannot process. "
+            f"Encoder error detail: {str(e)}"
+        ) from e
+
     columns_encoded = encoder.get_feature_names_out(data_to_encode.columns)
 
     df_encoded = pd.DataFrame(encoded_data, columns=columns_encoded).reset_index(drop=True)  # drop index from original
 
-    # Concatenate the encoded DataFrame with the original non-categorical columns
     df_result = pd.concat([df_columns_to_keep, df_encoded], axis=1)
 
     return df_result, encoder

--- a/tests/utils/test_encoding.py
+++ b/tests/utils/test_encoding.py
@@ -85,3 +85,18 @@ def test_one_hot_encode_consistent_with_new_data():
     c_z2 = df_encoded2["C_Z"]
     assert c_z1[2] == c_z2[1]
     assert c_z1[5] == c_z2[5]
+
+
+def test_one_hot_encode_nested_structures_raises_type_error():
+    """Ensure one_hot_encode throws a clear TypeError when an object column
+    contains non-primitive, unhashable, or nested data structures like dicts.
+    """
+    import pandas as pd
+    import pytest
+
+    from dowhy.utils.encoding import one_hot_encode
+
+    df = pd.DataFrame({"numeric_col": [1, 2, 3], "nested_col": [{"id": 1}, {"id": 2}, {"id": 3}]})
+
+    with pytest.raises(TypeError, match="categorical encoding failed during one-hot conversion"):
+        one_hot_encode(df, columns=["nested_col"])


### PR DESCRIPTION
### Summary
`one_hot_encode()` allows columns with complex, nested, or unhashable data structures (like dicts, lists, sets, or unaligned tuples) to pass completely unchecked into the underlying encoder block. This causes the library to leak cryptic, unhandled external dependency tracebacks (such as `TypeError: unhashable type`) from deep inside `scikit-learn` or `pandas` instead of raising a controlled framework message.

### Fix
Wrap the core `encoder.fit_transform()` and `encoder.transform()` execution blocks inside a clean `try-except` gate. This allows `scikit-learn` to remain the single source of truth for format compatibility while intercepting any runtime processing failures to raise a descriptive, unified `TypeError`. Additionally, add a dedicated regression unit test to `tests/utils/test_encoding.py`.

### Impact
- Callers now get a clear, explicit `TypeError` instead of a cryptic external dependency traceback when passing invalid column structures.
- Eliminates the need for a fragile, manual type-whitelist by letting the underlying encoder organically validate data compatibility.
- Adds a robust regression test to guarantee future validation coverage for unhashable types.

Fixes #1578 
Signed-off-by: abhiprd2000