### PR TITLE
Raise a clear error when one-hot encoding columns with unhashable values

### DIFF
--- a/dowhy/utils/encoding.py
+++ b/dowhy/utils/encoding.py
@@ -46,10 +46,24 @@ def one_hot_encode(data: pd.DataFrame, columns=None, drop_first: bool = False, e
             drop = "first"
         encoder = OneHotEncoder(drop=drop, sparse_output=False)  # NB sparse renamed to sparse_output in sklearn 1.2+
 
-        encoded_data = encoder.fit_transform(data_to_encode)
-
+        encode = encoder.fit_transform
     else:  # Use existing encoder
-        encoded_data = encoder.transform(data_to_encode)
+        encode = encoder.transform
+
+    # OneHotEncoder fails deep inside scikit-learn with a cryptic error (e.g.
+    # "unhashable type: 'numpy.ndarray'") when a categorical column holds
+    # non-scalar values such as lists, tuples, dicts or arrays. Surface a clear
+    # DoWhy-level message instead, leaving scikit-learn as the source of truth
+    # on what is encodable.
+    try:
+        encoded_data = encode(data_to_encode)
+    except TypeError as e:
+        raise TypeError(
+            "Failed to one-hot encode the categorical column(s) "
+            f"{list(data_to_encode.columns)}. They contain values that "
+            "scikit-learn cannot encode (e.g. lists, tuples, dicts or arrays). "
+            "Flatten or clean these columns to scalar values before estimation."
+        ) from e
 
     # Convert the encoded data to a DataFrame
     columns_encoded = encoder.get_feature_names_out(data_to_encode.columns)

--- a/tests/utils/test_encoding.py
+++ b/tests/utils/test_encoding.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import numpy as np
 import pandas as pd
+import pytest
 from _pytest.python_api import approx
 
 from dowhy.utils.encoding import one_hot_encode
@@ -85,3 +86,24 @@ def test_one_hot_encode_consistent_with_new_data():
     c_z2 = df_encoded2["C_Z"]
     assert c_z1[2] == c_z2[1]
     assert c_z1[5] == c_z2[5]
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [["a"], ["b"], ["a"], ["c"]],  # lists
+        [("a", 1), ("b", 2), ("a", 1), ("c", 3)],  # tuples
+        [{"a": 1}, {"b": 2}, {"a": 1}, {"c": 3}],  # dicts
+        [np.array([1]), np.array([2]), np.array([1]), np.array([3])],  # arrays
+    ],
+)
+def test_one_hot_encode_raises_clear_error_on_unhashable_columns(values):
+
+    # An object column holding non-scalar values (lists, tuples, dicts, arrays) makes
+    # scikit-learn fail with a cryptic error deep in its internals (e.g.
+    # "unhashable type: 'numpy.ndarray'"). DoWhy should surface a clear, actionable
+    # message instead of leaking the dependency crash. See issue #1578.
+    df = pd.DataFrame({"N": [1, 2, 3, 4], "C": values})
+
+    with pytest.raises(TypeError, match="Failed to one-hot encode"):
+        one_hot_encode(df)


### PR DESCRIPTION
Fixes #1578.

`one_hot_encode` selects `object`/`string`/`category` columns and passes them straight to scikit-learn's `OneHotEncoder`. When such a column holds non-scalar values (lists, tuples, dicts, numpy arrays), scikit-learn fails deep in its internals with a cryptic error that gives no hint the user's data is at fault — e.g. for the issue's example (a common-cause column of tuples):

```
File ".../sklearn/utils/_encode.py", line 272, in _check_unknown
    uniques_set = set(known_values)
TypeError: unhashable type: 'numpy.ndarray'
```

This wraps the `fit_transform`/`transform` call and re-raises a clear, actionable `TypeError` naming the offending column(s), while leaving scikit-learn as the single source of truth on what is encodable (no brittle type whitelist, as suggested in the issue):

```
TypeError: Failed to one-hot encode the categorical column(s) ['W1']. They contain
values that scikit-learn cannot encode (e.g. lists, tuples, dicts or arrays). Flatten
or clean these columns to scalar values before estimation.
```

### Testing
- Reproduced the original crash with the issue's exact example, and confirmed the clear message is raised for lists/tuples/dicts/arrays on both the `fit_transform` and `transform` paths.
- Normal string/categorical encoding and numeric-only inputs are unchanged.
- Added a parametrized regression test in `tests/utils/test_encoding.py`.
- `black --check` (line-length 120) and `flake8 --select=E9,F63,F7,F82` clean.
