### PR TITLE
Fix binary_flip crash on bool-dtype treatment/outcome in AddUnobservedCommonCause

### DIFF
--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -370,6 +370,9 @@ def _include_confounders_effect(
     w_random = stdnorm.rvs(num_rows, random_state=random_state)
 
     if effect_on_t == "binary_flip":
+        for tname in treatment_name:
+            if pd.api.types.is_bool_dtype(new_data[tname]):
+                new_data[tname] = new_data[tname].astype(int)
         alpha = 2 * kappa_t - 1 if kappa_t >= 0.5 else 1 - 2 * kappa_t
         interval = stdnorm.interval(alpha)
         rel_interval = interval[0] if kappa_t >= 0.5 else interval[1]
@@ -392,6 +395,9 @@ def _include_confounders_effect(
         raise NotImplementedError("'" + effect_on_t + "' method not supported for confounders' effect on treatment")
 
     if effect_on_y == "binary_flip":
+        for yname in outcome_name:
+            if pd.api.types.is_bool_dtype(new_data[yname]):
+                new_data[yname] = new_data[yname].astype(int)
         alpha = 2 * kappa_y - 1 if kappa_y >= 0.5 else 1 - 2 * kappa_y
         interval = stdnorm.interval(alpha)
         rel_interval = interval[0] if kappa_y >= 0.5 else interval[1]

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -666,3 +666,29 @@ def test_add_unobserved_common_cause_is_reproducible_with_random_state():
 
 def test_add_unobserved_common_cause_differs_across_random_states():
     assert _run_unobserved_refuter(random_state=123) != _run_unobserved_refuter(random_state=456)
+
+
+def test_add_unobserved_common_cause_binary_flip_with_bool_dtype():
+    import pandas as pd
+
+    rng = np.random.RandomState(0)
+    n = 400
+    w = rng.normal(size=n)
+    treatment = rng.uniform(size=n) < 1 / (1 + np.exp(-w))
+    outcome = rng.uniform(size=n) < 1 / (1 + np.exp(-(treatment.astype(int) + w)))
+    df = pd.DataFrame({"v0": treatment, "W0": w, "y": outcome})
+    assert df["v0"].dtype == bool and df["y"].dtype == bool
+
+    model = CausalModel(data=df, treatment="v0", outcome="y", common_causes=["W0"])
+    identified_estimand = model.identify_effect(proceed_when_unidentifiable=True)
+    estimate = model.estimate_effect(identified_estimand, method_name="backdoor.linear_regression")
+    refute = model.refute_estimate(
+        identified_estimand,
+        estimate,
+        method_name="add_unobserved_common_cause",
+        confounders_effect_on_treatment="binary_flip",
+        confounders_effect_on_outcome="binary_flip",
+        effect_strength_on_treatment=0.5,
+        effect_strength_on_outcome=0.5,
+    )
+    assert np.isfinite(refute.new_effect)


### PR DESCRIPTION
Closes #1587

## Problem
`add_unobserved_common_cause` with `confounders_effect_on_treatment="binary_flip"` (or the outcome equivalent) crashes when the treatment/outcome column has a boolean dtype:

```
TypeError: Invalid value '[0 0 0 1 ...]' for dtype 'bool'
```

In `_include_confounders_effect`, the flip is done as:

```python
new_data.loc[mask, treatment_name] = 1 - new_data.loc[mask, treatment_name]
```

When the column is `bool`, `1 - <bool series>` produces `int64`, and assigning that back into a boolean column raises on pandas ≥ 2.2 (hard error on pandas 3.x). The existing `astype({tname: "bool"})` cast-back runs *after* this assignment, so it never gets a chance to help.

This is reachable through the normal API whenever the treatment/outcome is boolean (e.g. `dowhy.datasets.linear_dataset(treatment_is_binary=True)` produces a `bool` treatment). The repo's own `test_refutation_binary_treatment` already exercises this path and fails on recent pandas.

## Fix
Cast boolean treatment/outcome columns to `int` *before* the flip; the existing trailing cast restores the original `bool` dtype. Six lines, both the treatment and outcome `binary_flip` branches.

## Tests
- Adds an explicit regression test with boolean treatment **and** boolean outcome under `binary_flip` for both.
- The existing `test_refutation_binary_treatment` now passes on pandas 3.x.

## Verification
Reproduced the crash on `main` (pandas 3.0.2), confirmed the fix resolves it and returns a valid refutation; `black`/`isort` clean.