### PR TITLE
Fix ConfounderDistributionInterpreter crash on categorical confounders

### DIFF
--- a/dowhy/interpreters/confounder_distribution_interpreter.py
+++ b/dowhy/interpreters/confounder_distribution_interpreter.py
@@ -54,12 +54,13 @@ class ConfounderDistributionInterpreter(VisualInterpreter):
         Plot of the treated vs untreated.
         """
 
-        ax.bar(labels - width / 2, not_treated_counts, width, label="Untreated")
-        ax.bar(labels + width / 2, treated_counts, width, label="Treated")
+        positions = np.arange(len(labels))
+        ax.bar(positions - width / 2, not_treated_counts, width, label="Untreated")
+        ax.bar(positions + width / 2, treated_counts, width, label="Treated")
         ax.set_xlabel(var_name)
         ax.set_ylabel("Count")
         ax.set_title(title, fontsize=font_size)
-        ax.set_xticks(labels)
+        ax.set_xticks(positions)
         ax.set_xticklabels(labels)
         ax.legend()
 
@@ -94,13 +95,12 @@ class ConfounderDistributionInterpreter(VisualInterpreter):
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=self.fig_size)
         iterable = zip([barplot_df_before, barplot_df_after], [ax1, ax2], [title1, title2])
         for plot_df, ax, title in iterable:
-            aggregated_not_treated = plot_df[plot_df[treated] == False].reset_index()
-            aggregated_treated = plot_df[plot_df[treated] == True].reset_index()
+            pivoted = plot_df.pivot_table(index=self.var_name, columns=treated, values="count", fill_value=0)
+            control_col, treated_col = pivoted.columns.min(), pivoted.columns.max()
 
-            labels = aggregated_not_treated[self.var_name].astype("float")
-            not_treated_counts = aggregated_not_treated["count"]
-
-            treated_counts = aggregated_treated["count"]
+            labels = pivoted.index.astype(str).tolist()
+            not_treated_counts = pivoted[control_col].to_numpy()
+            treated_counts = pivoted[treated_col].to_numpy()
             self.discrete_dist_plot(
                 labels, not_treated_counts, treated_counts, ax, title, self.var_name, self.font_size
             )

--- a/tests/test_confounder_distribution_interpreter.py
+++ b/tests/test_confounder_distribution_interpreter.py
@@ -1,0 +1,58 @@
+"""
+Regression tests for ConfounderDistributionInterpreter.
+
+Previously the interpreter cast the confounder column to float
+(`aggregated[...].astype("float")`) and used the values directly as bar
+positions, so it crashed with `ValueError: Cannot cast str dtype to float64`
+for categorical/string confounders — exactly the variables one wants to inspect
+for balance. It also misaligned the treated/untreated bars when a category was
+absent from one group. These tests verify it works for both categorical and
+integer-valued confounders.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dowhy import CausalModel
+
+
+def _build_estimate(confounder_name, confounder_values):
+    np.random.seed(42)
+    n = 500
+    w = np.random.normal(size=n)
+    treatment = (np.random.uniform(size=n) < 1 / (1 + np.exp(-w))).astype(int)
+    outcome = 2 * treatment + w + np.random.normal(size=n)
+    df = pd.DataFrame({"v0": treatment, "W0": w, confounder_name: confounder_values, "y": outcome})
+    model = CausalModel(data=df, treatment="v0", outcome="y", common_causes=["W0", confounder_name])
+    identified_estimand = model.identify_effect(proceed_when_unidentifiable=True)
+    estimate = model.estimate_effect(identified_estimand, method_name="backdoor.propensity_score_weighting")
+    return estimate, df
+
+
+@patch("matplotlib.pyplot.show")
+def test_confounder_distribution_interpreter_with_categorical_confounder(mock_show):
+    values = pd.Categorical(np.random.RandomState(0).choice(["a", "b", "c"], size=500))
+    estimate, df = _build_estimate("Wc", values)
+    estimate.interpret(
+        method_name="confounder_distribution_interpreter",
+        var_name="Wc",
+        var_type="discrete",
+        fig_size=(8, 4),
+        font_size=10,
+    )
+
+
+@patch("matplotlib.pyplot.show")
+def test_confounder_distribution_interpreter_with_integer_confounder(mock_show):
+    values = np.random.RandomState(0).randint(0, 3, size=500)
+    estimate, df = _build_estimate("Wi", values)
+    estimate.interpret(
+        method_name="confounder_distribution_interpreter",
+        var_name="Wi",
+        var_type="discrete",
+        fig_size=(8, 4),
+        font_size=10,
+    )


### PR DESCRIPTION
Closes #1588

## Problem
`ConfounderDistributionInterpreter` (reached via `estimate.interpret(method_name="confounder_distribution_interpreter", ...)`) crashes when the confounder is categorical/string:

```
ValueError: Cannot cast str dtype to float64
```

In `interpret()`, the confounder values were cast to float and used directly as bar x-positions:

```python
labels = aggregated_not_treated[self.var_name].astype("float")   # raises for string/categorical
...
ax.bar(labels - width / 2, ...)                                   # arithmetic needs numeric labels
```

Categorical variables are precisely the confounders you want to inspect for balance, so this fails on the primary use case.

A second, latent issue: the treated/untreated bars were taken from two separately-filtered frames and zipped positionally, so if a category was absent from one group the bars misaligned (or lengths mismatched).

## Fix
- Build the per-category treated/untreated counts with `pivot_table(..., fill_value=0)` so both series are aligned over the full set of categories (and missing categories count as 0).
- Use integer bar positions (`np.arange(len(labels))`) and set the category names as tick labels, instead of casting the values to float. This works for categorical, string, and numeric confounders alike.

## Tests
Adds `tests/test_confounder_distribution_interpreter.py` (the interpreter previously had no tests) covering a categorical confounder and an integer-valued confounder.

## Verification
Reproduced the crash on `main`; confirmed the fix renders for both categorical and integer confounders. `black`/`isort` clean.