### PR TITLE
fix: add descriptive error for out-of-bounds interventions in weighting_sampler (Closes #1344)

### DIFF
--- a/dowhy/do_samplers/weighting_sampler.py
+++ b/dowhy/do_samplers/weighting_sampler.py
@@ -47,6 +47,16 @@ class WeightingSampler(DoSampler):
         if not self.keep_original_treatment:
             for treatment, value in x.items():
                 to_sample = to_sample[to_sample[treatment] == value]
+
+        if len(to_sample) == 0:
+            raise ValueError(
+                "The intervention value(s) provided do not exactly match any observed "
+                "data points in the treatment column. The 'weighting' do-sampler relies on "
+                "exact matches (typically for discrete treatments). For continuous treatments "
+                "or interventions outside the observed distribution, consider using a different "
+                "sampling method or parametric model."
+            )
+
         self._df = to_sample
 
     def disrupt_causes(self):

--- a/tests/do_sampler/test_pandas_do_api.py
+++ b/tests/do_sampler/test_pandas_do_api.py
@@ -245,3 +245,16 @@ class TestPandasDoAPI(object):
             variable_types=dict(x="c", y="c", a="c", b="c"),
         )
         print(dd)
+
+    def test_weighting_sampler_raises_value_error_out_of_bounds(self):
+        import pytest
+
+        df = pd.DataFrame({"x": [0, 0.5, 1], "y": [1, 0.5, 0], "a": [0, 0.5, 0], "b": [0.25, 0, 0]})
+        with pytest.raises(ValueError, match="The intervention value.*do not exactly match"):
+            df.causal.do(
+                x={"x": 2.0},
+                outcome="y",
+                common_causes=["a", "b"],
+                variable_types=dict(x="c", y="c", a="c", b="c"),
+                method="weighting",
+            )


### PR DESCRIPTION
### Problem
When using the `weighting` do-sampler, passing an intervention value that is outside the observed bounds of the treatment column (or a continuous value that doesn't exactly match) silently fails or results in empty DataFrames downstream.

### Fix
Added an explicit check in `WeightingSampler` that raises a descriptive `ValueError` if the filtered `to_sample` DataFrame is empty. This provides a graceful error boundary guiding the user to either use observed discrete values or switch to a different sampling method for continuous interventions. Closes #1344.

### Tests
- Added an explicit regression test `test_weighting_sampler_raises_value_error_out_of_bounds` in `test_pandas_do_api.py` to verify the `ValueError` is raised correctly on out-of-bounds interventions.

### Verification
- Merged the latest `main` to resolve the out-of-date branch status.
- Added test coverage for the exact bug.
