### PR TITLE
tests: ignore flaky gcm_chest_xray_causal_inference notebook in CI

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -41,6 +41,7 @@ py310_dependent_notebooks = {
 #       most get tested by the documentation generation.
 ignore_notebooks = [
     "dowhy_causal_discovery_example.ipynb",  # This is being tested as part of documentation generation
+    "gcm_chest_xray_causal_inference.ipynb",  # Requires network download; flaky in CI due to HTTP 429
 ]
 
 # Adding the dowhy root folder to the python path so that jupyter notebooks


### PR DESCRIPTION
Added 'gcm_chest_xray_causal_inference.ipynb' to ignore list due to network issues.

This PR adds gcm_chest_xray_causal_inference.ipynb to ignore_notebooks in tests/test_notebooks.py.
Rationale: notebook execution depends on external downloads and fails intermittently in CI with rate limiting (HTTP Error 429: Too Many Requests).
Failing job reference: https://github.com/py-why/dowhy/actions/runs/27739381495/job/82062996293?pr=1413