### PR TITLE
Clarify significance output and add dedicated significance_level parameter

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -36,6 +36,8 @@ class CausalEstimator:
     DEFAULT_SAMPLE_SIZE_FRACTION = 1
     # The default Confidence Level
     DEFAULT_CONFIDENCE_LEVEL = 0.95
+    # The default significance level (alpha) for the statistical significance test
+    DEFAULT_SIGNIFICANCE_LEVEL = 0.05
     # Number of quantiles to discretize continuous columns, for applying groupby
     NUM_QUANTILES_TO_DISCRETIZE_CONT_COLS = 5
     # Prefix to add to temporary categorical variables created after discretization
@@ -60,6 +62,7 @@ class CausalEstimator:
         num_simulations: int = DEFAULT_NUMBER_OF_SIMULATIONS_CI,
         sample_size_fraction: int = DEFAULT_SAMPLE_SIZE_FRACTION,
         confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
+        significance_level: float = DEFAULT_SIGNIFICANCE_LEVEL,
         need_conditional_estimates: Union[bool, str] = "auto",
         num_quantiles_to_discretize_cont_cols: int = NUM_QUANTILES_TO_DISCRETIZE_CONT_COLS,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
@@ -82,6 +85,10 @@ class CausalEstimator:
             estimator
         :param confidence_level: The confidence level of the confidence
             interval estimate
+        :param significance_level: The significance level (alpha) used to decide
+            whether the estimate is statistically significant when test_significance
+            is enabled. Defaults to 0.05. This is independent of confidence_level,
+            which controls the width of confidence intervals.
         :param need_conditional_estimates: Boolean flag indicating whether
             conditional estimates should be computed. Defaults to True if
             there are effect modifiers in the graph
@@ -110,6 +117,7 @@ class CausalEstimator:
         self.num_simulations = num_simulations
         self.sample_size_fraction = sample_size_fraction
         self.confidence_level = confidence_level
+        self.significance_level = significance_level
         self.num_quantiles_to_discretize_cont_cols = num_quantiles_to_discretize_cont_cols
         # Estimate conditional estimates by default
         self.need_conditional_estimates = need_conditional_estimates
@@ -761,13 +769,49 @@ class CausalEstimator:
         return s
 
     def signif_results_tostr(self, signif_results):
-        s = ""
+        """Format the significance test result as a human-readable string.
+
+        The p-value is reported as a single number, except when the estimate is
+        more extreme than every bootstrap null sample, in which case the exact
+        value cannot be determined from a finite number of simulations and a
+        bound is reported instead (``p < x`` or ``p > x``). A conclusion is added
+        based on ``significance_level`` (alpha): "significant", "not significant",
+        or "inconclusive" when the bound straddles alpha.
+
+        :param signif_results: dict with key ``p_value`` (float, 2-tuple bound, or
+            numpy array for multiple treatments).
+        :returns: formatted string with the p-value and the significance conclusion.
+        """
+        alpha = self.significance_level
         pval = signif_results["p_value"]
-        if type(pval) is tuple:
-            s += "[{0}, {1}]".format(pval[0], pval[1])
+
+        def _conclusion(is_significant):
+            return "significant" if is_significant else "not significant"
+
+        if isinstance(pval, tuple):
+            low, high = pval
+            if low == 0:
+                pval_str = "p < {:.2g}".format(high)
+            elif high == 1:
+                pval_str = "p > {:.2g}".format(low)
+            else:
+                pval_str = "{:.2g} < p < {:.2g}".format(low, high)
+            if high <= alpha:
+                conclusion = _conclusion(True)
+            elif low >= alpha:
+                conclusion = _conclusion(False)
+            else:
+                conclusion = "inconclusive (limited by the number of simulations)"
+        elif isinstance(pval, np.ndarray):
+            pval_str = "[{}]".format(", ".join("{:.2g}".format(p) for p in pval))
+            conclusion = "[{}]".format(", ".join(_conclusion(p <= alpha) for p in pval))
         else:
-            s += "{0}".format(pval)
-        return s
+            pval_str = "{:.2g}".format(pval)
+            conclusion = _conclusion(pval <= alpha)
+
+        return "{} ({} at alpha={:.2g}; H0: treatment has no causal effect on outcome)".format(
+            pval_str, conclusion, alpha
+        )
 
 
 def estimate_effect(

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -791,11 +791,11 @@ class CausalEstimator:
         if isinstance(pval, tuple):
             low, high = pval
             if low == 0:
-                pval_str = "p < {:.2g}".format(high)
+                pval_str = "p < {:.3g}".format(high)
             elif high == 1:
-                pval_str = "p > {:.2g}".format(low)
+                pval_str = "p > {:.3g}".format(low)
             else:
-                pval_str = "{:.2g} < p < {:.2g}".format(low, high)
+                pval_str = "{:.3g} < p < {:.3g}".format(low, high)
             if high <= alpha:
                 conclusion = _conclusion(True)
             elif low >= alpha:
@@ -803,13 +803,13 @@ class CausalEstimator:
             else:
                 conclusion = "inconclusive (limited by the number of simulations)"
         elif isinstance(pval, np.ndarray):
-            pval_str = "[{}]".format(", ".join("{:.2g}".format(p) for p in pval))
+            pval_str = "[{}]".format(", ".join("{:.3g}".format(p) for p in pval))
             conclusion = "[{}]".format(", ".join(_conclusion(p <= alpha) for p in pval))
         else:
-            pval_str = "{:.2g}".format(pval)
+            pval_str = "{:.3g}".format(pval)
             conclusion = _conclusion(pval <= alpha)
 
-        return "{} ({} at alpha={:.2g}; H0: treatment has no causal effect on outcome)".format(
+        return "{} ({} at alpha={:.3g}; H0: treatment has no causal effect on outcome)".format(
             pval_str, conclusion, alpha
         )
 

--- a/tests/causal_estimators/test_significance_reporting.py
+++ b/tests/causal_estimators/test_significance_reporting.py
@@ -1,0 +1,69 @@
+"""
+Tests for the human-readable significance reporting in CausalEstimator.
+
+Covers the formatting of bootstrap significance results (resolving the
+ambiguity reported in issue #879) and the dedicated ``significance_level``
+parameter, which is independent of the confidence-interval ``confidence_level``.
+"""
+
+import numpy as np
+
+from dowhy.causal_estimator import CausalEstimator
+
+
+class _Estimator:
+    """Minimal stand-in exposing only what signif_results_tostr needs."""
+
+    significance_level = CausalEstimator.DEFAULT_SIGNIFICANCE_LEVEL
+
+
+def _fmt(p_value, significance_level=None):
+    est = _Estimator()
+    if significance_level is not None:
+        est.significance_level = significance_level
+    return CausalEstimator.signif_results_tostr(est, {"p_value": p_value})
+
+
+def test_scalar_pvalue_significant():
+    result = _fmt(0.03)
+    assert "0.03" in result
+    assert "not significant" not in result
+    assert "significant" in result
+    assert "alpha=0.05" in result
+    assert "H0" in result
+
+
+def test_scalar_pvalue_not_significant():
+    result = _fmt(0.2)
+    assert "not significant" in result
+
+
+def test_lower_bound_pvalue_uses_less_than():
+    # (0, hi) means the estimate is more extreme than every null sample.
+    result = _fmt((0, 0.001))
+    assert "p < 0.001" in result
+    assert "[" not in result  # the old ambiguous "[0, 0.001]" form is gone
+    assert "significant" in result and "not significant" not in result
+
+
+def test_upper_bound_pvalue_uses_greater_than():
+    result = _fmt((0.99, 1))
+    assert "p > 0.99" in result
+    assert "not significant" in result
+
+
+def test_array_pvalue_reports_each_treatment():
+    result = _fmt(np.array([0.01, 0.3]))
+    assert "0.01" in result and "0.3" in result
+    assert "significant" in result
+
+
+def test_significance_level_is_independent_of_confidence_level():
+    # The same p-value bound is significant at alpha=0.05 but inconclusive at
+    # the stricter alpha=0.01 -- the verdict must follow significance_level only.
+    assert "significant" in _fmt((0, 0.02), significance_level=0.05)
+    assert "inconclusive" in _fmt((0, 0.02), significance_level=0.01)
+
+
+def test_default_significance_level():
+    assert CausalEstimator.DEFAULT_SIGNIFICANCE_LEVEL == 0.05

--- a/tests/causal_estimators/test_significance_reporting.py
+++ b/tests/causal_estimators/test_significance_reporting.py
@@ -27,8 +27,7 @@ def _fmt(p_value, significance_level=None):
 def test_scalar_pvalue_significant():
     result = _fmt(0.03)
     assert "0.03" in result
-    assert "not significant" not in result
-    assert "significant" in result
+    assert "(significant at" in result
     assert "alpha=0.05" in result
     assert "H0" in result
 
@@ -43,7 +42,7 @@ def test_lower_bound_pvalue_uses_less_than():
     result = _fmt((0, 0.001))
     assert "p < 0.001" in result
     assert "[" not in result  # the old ambiguous "[0, 0.001]" form is gone
-    assert "significant" in result and "not significant" not in result
+    assert "(significant at" in result
 
 
 def test_upper_bound_pvalue_uses_greater_than():
@@ -53,15 +52,16 @@ def test_upper_bound_pvalue_uses_greater_than():
 
 
 def test_array_pvalue_reports_each_treatment():
+    # 0.01 is below alpha=0.05 (significant); 0.3 is above (not significant).
     result = _fmt(np.array([0.01, 0.3]))
     assert "0.01" in result and "0.3" in result
-    assert "significant" in result
+    assert "[significant, not significant]" in result
 
 
 def test_significance_level_is_independent_of_confidence_level():
     # The same p-value bound is significant at alpha=0.05 but inconclusive at
     # the stricter alpha=0.01 -- the verdict must follow significance_level only.
-    assert "significant" in _fmt((0, 0.02), significance_level=0.05)
+    assert "(significant at" in _fmt((0, 0.02), significance_level=0.05)
     assert "inconclusive" in _fmt((0, 0.02), significance_level=0.01)
 
 


### PR DESCRIPTION
Closes #879

Follow up to the discussion on #1488, where @emrekiciman asked for help landing this. This supersedes #1488: it keeps that PR's idea of replacing the ambiguous `[lo, hi]` p-value with a clear bound + verdict, and additionally addresses the two points I raised in review , the conflation of the significance threshold with `confidence_level`, and the still-missing null hypothesis. Credit to the original #1488 work for the formatting direction.

## What #879 asked for
1. *"Why is there a list for the p-values?"* , the output showed `[0.0, 0.0025]`.
2. *"It's ambiguous what the null hypothesis is."*
3. *"It would be great to print the result (significant / non-significant)."*

## Changes
- **Clear p-value formatting.** `signif_results_tostr` now reports a single value, or a bound (`p < x` / `p > x`) when the estimate is more extreme than every bootstrap null sample (where the exact value can't be determined from a finite number of simulations). Multiple-treatment (numpy array) p-values are formatted per element.
- **A verdict.** The output states "significant" / "not significant", or "inconclusive" when a bound straddles alpha.
- **The null hypothesis is stated** in the output: `H0: treatment has no causal effect on outcome`.
- **A dedicated `significance_level` (alpha) parameter** on `CausalEstimator`, defaulting to 0.05. Previously there was no significance threshold at all; deriving it from `confidence_level` (a confidence-interval concept) would couple two independent settings  e.g. widening intervals with `confidence_level=0.99` should not silently move the significance threshold to 0.01.

The programmatic result (`estimate.test_stat_significance()["p_value"]`) is unchanged; only the human readable string and the new optional parameter are added, so this is backward compatible.

### Before
```
p-value: [0.0, 0.0025]
```
### After
```
p-value: p < 0.0025 (significant at alpha=0.05; H0: treatment has no causal effect on outcome)
```

## Tests
Adds `tests/causal_estimators/test_significance_reporting.py` covering scalar / lower-bound / upper-bound / numpy-array p-values, the significance verdict, and that `significance_level` is independent of `confidence_level`.

## Note on #841
The related ask in #841 (raise the default number of CI simulations) already appears to be handled on `main` — `DEFAULT_NUMBER_OF_SIMULATIONS_CI` is 399.