### PR TITLE
Fix conditional effect estimation crash on pandas >= 3.0 (include_groups removed)

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -333,16 +333,14 @@ class CausalEstimator:
         # Adding observed=True to avoid a FutureWarning in pandas (see #1316)
         by_effect_mods = data.groupby(effect_modifier_names, observed=True)
 
-        # pandas >=2.2 emits a DeprecationWarning when the grouping columns are
-        # passed to the applied function unless include_groups is specified
-        # explicitly. We pass include_groups=True because estimators may access
-        # the effect-modifier columns (grouping columns) inside estimate_effect_fn
-        # for feature construction. Older pandas versions do not accept this
-        # keyword, so we fall back gracefully.
-        try:
-            conditional_estimates = by_effect_mods.apply(estimate_effect_fn, include_groups=True)
-        except TypeError:
-            conditional_estimates = by_effect_mods.apply(estimate_effect_fn)
+        # Some estimators access the effect-modifier (grouping) columns inside
+        # estimate_effect_fn for feature construction, so those columns must remain
+        # available. pandas >=3.0 no longer lets GroupBy.apply include the grouping
+        # columns (include_groups=True was removed). Iterating the groups keeps the
+        # grouping columns in each sub-frame across all pandas versions.
+        group_estimates = {group_key: estimate_effect_fn(group_df) for group_key, group_df in by_effect_mods}
+        conditional_estimates = pd.Series(group_estimates)
+        conditional_estimates.index.names = effect_modifier_names
         # Deleting the temporary categorical columns
         for em in effect_modifier_names:
             if em.startswith(prefix):

--- a/tests/causal_estimators/test_conditional_effects.py
+++ b/tests/causal_estimators/test_conditional_effects.py
@@ -1,0 +1,50 @@
+"""
+Regression test for conditional effect estimation across effect modifiers.
+
+`_estimate_conditional_effects` previously called
+`groupby(...).apply(fn, include_groups=True)`, which raises
+`ValueError: include_groups=True is no longer allowed` on pandas >= 3.0.
+These tests confirm conditional effects are computed for single and multiple
+effect modifiers, and that the estimators can still access the effect-modifier
+(grouping) columns during feature construction.
+"""
+
+import numpy as np
+import pandas as pd
+
+import dowhy.datasets
+from dowhy import CausalModel
+
+
+def _conditional_estimates(num_effect_modifiers):
+    data = dowhy.datasets.linear_dataset(
+        beta=10,
+        num_common_causes=3,
+        num_effect_modifiers=num_effect_modifiers,
+        num_samples=2000,
+        treatment_is_binary=True,
+    )
+    model = CausalModel(
+        data=data["df"],
+        treatment=data["treatment_name"],
+        outcome=data["outcome_name"],
+        graph=data["gml_graph"],
+    )
+    identified_estimand = model.identify_effect(proceed_when_unidentifiable=True)
+    estimate = model.estimate_effect(identified_estimand, method_name="backdoor.linear_regression")
+    return estimate.conditional_estimates
+
+
+def test_conditional_effects_single_effect_modifier():
+    conditional_estimates = _conditional_estimates(num_effect_modifiers=1)
+    assert isinstance(conditional_estimates, pd.Series)
+    assert len(conditional_estimates) > 0
+    assert np.all(np.isfinite(conditional_estimates.values))
+
+
+def test_conditional_effects_multiple_effect_modifiers():
+    conditional_estimates = _conditional_estimates(num_effect_modifiers=2)
+    assert isinstance(conditional_estimates, pd.Series)
+    assert isinstance(conditional_estimates.index, pd.MultiIndex)
+    assert len(conditional_estimates) > 0
+    assert np.all(np.isfinite(conditional_estimates.values))


### PR DESCRIPTION
Closes #1608

## Problem
Estimating an effect with effect modifiers present (which triggers conditional effect estimation) crashes on pandas >= 3.0:

```
ValueError: include_groups=True is no longer allowed.
```

`_estimate_conditional_effects` used:
```python
try:
    conditional_estimates = by_effect_mods.apply(estimate_effect_fn, include_groups=True)
except TypeError:
    conditional_estimates = by_effect_mods.apply(estimate_effect_fn)
```
`include_groups=True` was deprecated in pandas 2.2 and removed in pandas 3.0, where it raises `ValueError` (not `TypeError`), so the existing fallback doesn't catch it.

Simply falling back to `apply(estimate_effect_fn)` is not a fix either: on pandas 3.0 that excludes the grouping columns, and estimators like `RegressionEstimator` need the effect-modifier (grouping) columns for feature construction — that path raises `KeyError: ['X1'] not in index`.

## Fix
Iterate the groups instead of using `GroupBy.apply`. Group iteration keeps the grouping columns in each sub-frame on every pandas version, so the effect-modifier columns remain available to `estimate_effect_fn`:

```python
group_estimates = {group_key: estimate_effect_fn(group_df) for group_key, group_df in by_effect_mods}
conditional_estimates = pd.Series(group_estimates)
conditional_estimates.index.names = effect_modifier_names
```

This reproduces the previous output (a Series of per-group estimates indexed by the effect-modifier values, with a MultiIndex when there is more than one modifier) without depending on the removed `include_groups` behavior.

## Tests
Adds `tests/causal_estimators/test_conditional_effects.py` covering single and multiple effect modifiers (the latter asserting a MultiIndex result).

## Verification
Reproduced the crash on `main` (pandas 3.0.2); confirmed the fix computes conditional estimates for single and multiple effect modifiers, and the existing `test_linear_regression_estimator.py` suite (which exercises conditional effects) still passes. `black`/`isort` clean.