### PR TITLE
Fix DummyOutcomeRefuter read-only array crash with permute on pandas >= 3.0

### DIFF
--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -308,7 +308,7 @@ def _refute_once(
 
         # Get true causal effect (should be computed once and passed in)
         true_effect = true_causal_effect(validation_df[treatment_name[0]])
-        outcome_validation += true_effect
+        outcome_validation = outcome_validation + true_effect
 
         new_data = validation_df.assign(dummy_outcome=outcome_validation)
 
@@ -383,7 +383,7 @@ def _refute_once(
             true_effect = true_causal_effect(validation_df[treatment_name[0]])
 
             # Add h(t) to f(W) to get the dummy outcome
-            outcome_validation += true_effect
+            outcome_validation = outcome_validation + true_effect
 
             new_data = validation_df.assign(dummy_outcome=outcome_validation)
             new_estimator = estimate.estimator.get_new_estimator_object(identified_estimand)
@@ -915,6 +915,7 @@ def permute(
         outcome.columns = [outcome_name]
         return outcome[outcome_name].sample(frac=1, random_state=random_state).values
     elif permute_fraction < 1:
+        outcome = np.array(outcome)
         permute_fraction /= 2  # We do this as every swap leads to two changes
         changes = np.where(rng.uniform(0, 1, outcome.shape[0]) <= permute_fraction)[
             0

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -915,7 +915,9 @@ def permute(
         outcome.columns = [outcome_name]
         return outcome[outcome_name].sample(frac=1, random_state=random_state).values
     elif permute_fraction < 1:
-        outcome = np.array(outcome)
+        outcome = np.asarray(outcome)
+        if not outcome.flags.writeable:
+            outcome = outcome.copy()
         permute_fraction /= 2  # We do this as every swap leads to two changes
         changes = np.where(rng.uniform(0, 1, outcome.shape[0]) <= permute_fraction)[
             0


### PR DESCRIPTION
Closes #1631

## Problem
`dummy_outcome_refuter` with a `permute` transformation crashes on pandas >= 3.0:

```
ValueError: output array is read-only
```

Under pandas >= 3.0 (Copy-on-Write), `Series.values` and `Series.sample(...).values` return **read-only** arrays. Two spots in `dowhy/causal_refuters/dummy_outcome_refuter.py` then mutate such arrays in place:

1. `outcome_validation += true_effect` (both the estimator-absent and estimator-present branches) — in-place add on a read-only array.
2. `permute()` performs an in-place Fisher-Yates swap (`outcome[change] = outcome[index]`) when `permute_fraction < 1`.

## Fix
- Replace the in-place `outcome_validation += true_effect` with an out-of-place `outcome_validation = outcome_validation + true_effect`, which allocates a fresh writable array.
- In `permute()`, take a writable copy (`outcome = np.array(outcome)`) before the in-place swaps.

Both changes are behavior-preserving on older pandas.

## Tests
The existing `tests/causal_refuters/test_dummy_outcome_refuter.py` permute cases (`..._permute_data_continuous_treatment`, `..._permute_data_binary_treatment`, `..._custom_function_..._with_permute_...`) exercise both code paths; they fail on `main` with pandas 3.x and pass with this fix. The full file passes (20 passed, 2 xfailed).

## Verification
Reproduced on `main` with pandas 3.0.2; confirmed the fix. `black`/`isort` clean.