### PR TITLE
fix(distance_matching): accept int-encoded binary treatment without raising

### DIFF
--- a/dowhy/causal_estimators/distance_matching_estimator.py
+++ b/dowhy/causal_estimators/distance_matching_estimator.py
@@ -138,8 +138,10 @@ class DistanceMatchingEstimator(CausalEstimator):
             error_msg = "{} cannot handle more than one treatment variable".format(self.__class__.__name__)
             raise ValueError(error_msg)
         # Checking if the treatment is binary
-        if not data[self._target_estimand.treatment_variable[0]].isin([0, 1]).all():
-            error_msg = "Distance Matching method is applicable only for binary treatments."
+        treatment_var = self._target_estimand.treatment_variable[0]
+        treatment_values = data[treatment_var].astype(int).unique()
+        if not (len(treatment_values) == 2 and set(treatment_values).issubset({0, 1})):
+            error_msg = "Distance Matching method is applicable only for binary treatments (0 and 1)."
             self.logger.error(error_msg)
             raise ValueError(error_msg)
 

--- a/tests/causal_estimators/test_distance_matching_estimator.py
+++ b/tests/causal_estimators/test_distance_matching_estimator.py
@@ -233,3 +233,30 @@ class TestDistanceMatchingEstimator:
             },
         )
         assert np.isfinite(estimate.value), "Estimate with Mahalanobis and V param should be finite."
+
+    def test_binary_treatment_int_dtype_issue772(self):
+        """Regression test for Issue #772.
+
+        DistanceMatchingEstimator should accept binary treatment encoded as int
+        (0/1) without raising "binary treatments" ValueError.
+        """
+        rng = np.random.default_rng(772)
+        n = 500
+        w = rng.standard_normal(n)
+        # Explicitly keep as int dtype (not bool, not float)
+        treatment = ((w + rng.standard_normal(n) > 0)).astype(int)
+        outcome = 10 * treatment + 2 * w + rng.standard_normal(n)
+        data = pd.DataFrame({"W": w, "v0": treatment, "y": outcome})
+
+        # Verify dtype is int
+        assert data["v0"].dtype in [np.int64, np.int32, int], f"Treatment dtype is {data['v0'].dtype}, expected int"
+
+        model = CausalModel(data=data, treatment="v0", outcome="y", graph=GML_SINGLE_CAUSE)
+        estimand = model.identify_effect(proceed_when_unidentifiable=True)
+        # This should NOT raise
+        estimate = model.estimate_effect(
+            estimand,
+            method_name="backdoor.distance_matching",
+            target_units="ate",
+        )
+        assert np.isfinite(estimate.value), "Estimate should be finite"


### PR DESCRIPTION
Closes #772.

The binary treatment check in DistanceMatchingEstimator now converts to int before checking unique values, then verifies exactly two values {0, 1}. This handles bool, int, and float encodings robustly across pandas versions.

Includes a regression test that uses explicit .astype(int) on the treatment column to reproduce the reported failure.