### PR TITLE
Fix gcm Shapley least-squares estimation on scikit-learn 1.9

### DIFF
--- a/dowhy/gcm/shapley.py
+++ b/dowhy/gcm/shapley.py
@@ -10,7 +10,6 @@ import scipy
 from joblib import Parallel, delayed
 from scipy.special import comb
 from scipy.stats._qmc import Halton
-from sklearn.linear_model import LinearRegression
 from tqdm import tqdm
 
 import dowhy.gcm.config as config
@@ -231,7 +230,31 @@ def _approximate_shapley_values_via_least_squares_regression(
             )
         )
 
-    return LinearRegression().fit(all_subsets, np.array(set_function_results), sample_weight=weights).coef_
+    return _weighted_least_squares_coefficients(all_subsets, np.array(set_function_results), weights)
+
+
+def _weighted_least_squares_coefficients(
+    all_subsets: np.ndarray, set_function_results: np.ndarray, weights: np.ndarray
+) -> np.ndarray:
+    """Solves the weighted least squares problem (with intercept) and returns the coefficients.
+
+    The weights span many orders of magnitude (the full and empty subsets get weight 10**20 to
+    approximate equality constraints), which makes the system extremely ill-conditioned. Solving
+    it explicitly via lstsq on the square-root-weighted system keeps the solution stable and
+    independent of solver changes in third-party libraries.
+    """
+    sqrt_weights = np.sqrt(weights)
+    # Center predictors and targets by their weighted means (this implicitly handles the
+    # intercept and keeps the system well-behaved despite the extreme weights).
+    subsets_mean = np.average(all_subsets, axis=0, weights=weights)
+    targets_mean = np.average(set_function_results, axis=0, weights=weights)
+    centered_subsets = (all_subsets - subsets_mean) * sqrt_weights[:, np.newaxis]
+    if set_function_results.ndim == 1:
+        centered_targets = (set_function_results - targets_mean) * sqrt_weights
+    else:
+        centered_targets = (set_function_results - targets_mean) * sqrt_weights[:, np.newaxis]
+    coefficients = np.linalg.lstsq(centered_subsets, centered_targets, rcond=None)[0]
+    return coefficients if set_function_results.ndim == 1 else coefficients.T
 
 
 def _approximate_shapley_values_via_permutation_sampling(

--- a/tests/gcm/test_shapley.py
+++ b/tests/gcm/test_shapley.py
@@ -5,7 +5,12 @@ import pytest
 from flaky import flaky
 from pytest import approx
 
-from dowhy.gcm.shapley import ShapleyApproximationMethods, ShapleyConfig, estimate_shapley_values
+from dowhy.gcm.shapley import (
+    ShapleyApproximationMethods,
+    ShapleyConfig,
+    _weighted_least_squares_coefficients,
+    estimate_shapley_values,
+)
 from dowhy.gcm.stats import permute_features
 from dowhy.gcm.util.general import means_difference
 
@@ -233,3 +238,38 @@ def _set_function_for_aggregated_feature_attribution(subset, X, model, evaluate_
         return means_difference(model(tmp), X[0])
     else:
         return np.array([means_difference(model(tmp), x) for x in X])
+
+
+def test_given_single_and_multi_output_targets_when_solving_weighted_least_squares_then_returns_expected_coefficients():
+    num_subsets = 200
+    num_players = 6
+    rng = np.random.RandomState(0)
+
+    all_subsets = (rng.uniform(size=(num_subsets, num_players)) < 0.5).astype(float)
+    all_subsets[0] = 0.0
+    all_subsets[1] = 1.0
+    # The full and empty subsets act as equality constraints and carry an extreme weight.
+    weights = np.ones(num_subsets)
+    weights[0] = weights[1] = 10**20
+
+    single_output_coefficients = rng.normal(size=num_players)
+    second_output_coefficients = rng.normal(size=num_players)
+    intercept = 3.0
+
+    estimated = _weighted_least_squares_coefficients(
+        all_subsets, all_subsets @ single_output_coefficients + intercept, weights
+    )
+    assert estimated.shape == (num_players,)
+    assert estimated == approx(single_output_coefficients, abs=1e-8)
+
+    multi_output_targets = np.column_stack(
+        [
+            all_subsets @ single_output_coefficients + intercept,
+            all_subsets @ second_output_coefficients - intercept,
+        ]
+    )
+    estimated_multi_output = _weighted_least_squares_coefficients(all_subsets, multi_output_targets, weights)
+    # Matches the (n_outputs, n_features) layout of LinearRegression.coef_
+    assert estimated_multi_output.shape == (2, num_players)
+    assert estimated_multi_output[0] == approx(single_output_coefficients, abs=1e-8)
+    assert estimated_multi_output[1] == approx(second_output_coefficients, abs=1e-8)


### PR DESCRIPTION
Closes #1698. Part of #1665 (found by the latest-deps job in #1672).

## Problem
The `EXACT_FAST` and `SUBSET_SAMPLING` Shapley approximations solve a weighted least squares problem via `LinearRegression().fit(..., sample_weight=weights)`, where the full/empty subsets carry weight `10**20` to approximate equality constraints. scikit-learn 1.9.0 changed `LinearRegression`'s sample-weight solve path, and with weights spanning 20 orders of magnitude the returned coefficients are now completely wrong (see the minimal repro in #1698: max coefficient error goes from ~1e-14 on 1.8.0 to ~2.1 on 1.9.0). Three `test_shapley` tests fail on scikit-learn 1.9.

## Fix
Replace the `LinearRegression` call with an explicit weighted least squares solve: center predictors and targets by their weighted means (which handles the intercept and, with the extreme weights, keeps the system well-behaved), then solve the square-root-weighted system with `np.linalg.lstsq`. This reproduces the numerically stable behavior and decouples the result from solver changes in third-party libraries. Also removes the now-unused `LinearRegression` import.

## Verification
- The three failing `test_shapley` tests pass on **both** scikit-learn 1.8.0 and 1.9.0 with this change (all 10 tests in the file green on both).
- Downstream consumers of the least-squares path are unaffected: `test_feature_relevance` and `test_arrow_strength` pass on scikit-learn 1.9.0.
- `black`/`isort` clean.