### PR TITLE
Fix conditional effects for constant numeric modifiers

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -17,6 +17,23 @@ from dowhy.utils.encoding import Encoders
 logger = logging.getLogger(__name__)
 
 
+def _discretize_numeric_effect_modifier(values: pd.Series, num_quantiles: int) -> pd.Series:
+    """Discretize numeric effect-modifier values without losing a constant observed group."""
+    # qcut produces an all-NA categorical for a constant column, which drops its only observed group.
+    if values.nunique(dropna=True) <= 1:
+        return values.astype("category")
+    return pd.qcut(values, num_quantiles, duplicates="drop")
+
+
+def _create_conditional_estimates(group_keys, group_estimates, effect_modifier_names) -> pd.Series:
+    """Create a correctly shaped result index, including when there are no observed groups."""
+    if len(effect_modifier_names) == 1:
+        group_index = pd.Index(group_keys, name=effect_modifier_names[0])
+    else:
+        group_index = pd.MultiIndex.from_tuples(group_keys, names=effect_modifier_names)
+    return pd.Series(group_estimates, index=group_index)
+
+
 class CausalEstimator:
     """Base class for an estimator of causal effect.
 
@@ -336,20 +353,26 @@ class CausalEstimator:
         for i in range(len(effect_modifier_names)):
             em = effect_modifier_names[i]
             if pd.api.types.is_numeric_dtype(data[em].dtypes):
-                data[prefix + str(em)] = pd.qcut(data[em], num_quantiles, duplicates="drop")
-                effect_modifier_names[i] = prefix + str(em)
+                categorical_em = prefix + str(em)
+                data[categorical_em] = _discretize_numeric_effect_modifier(data[em], num_quantiles)
+                effect_modifier_names[i] = categorical_em
         # Grouping by effect modifiers and computing effect separately
         # Adding observed=True to avoid a FutureWarning in pandas (see #1316)
-        by_effect_mods = data.groupby(effect_modifier_names, observed=True)
+        groupby_columns = effect_modifier_names[0] if len(effect_modifier_names) == 1 else effect_modifier_names
+        by_effect_mods = data.groupby(groupby_columns, observed=True)
 
         # Some estimators access the effect-modifier (grouping) columns inside
         # estimate_effect_fn for feature construction, so those columns must remain
         # available. pandas >=3.0 no longer lets GroupBy.apply include the grouping
         # columns (include_groups=True was removed). Iterating the groups keeps the
         # grouping columns in each sub-frame across all pandas versions.
-        group_estimates = {group_key: estimate_effect_fn(group_df) for group_key, group_df in by_effect_mods}
-        conditional_estimates = pd.Series(group_estimates)
-        conditional_estimates.index.names = effect_modifier_names
+        group_keys = []
+        group_estimates = []
+        for group_key, group_df in by_effect_mods:
+            group_keys.append(group_key)
+            group_estimates.append(estimate_effect_fn(group_df))
+
+        conditional_estimates = _create_conditional_estimates(group_keys, group_estimates, effect_modifier_names)
         # Deleting the temporary categorical columns
         for em in effect_modifier_names:
             if em.startswith(prefix):

--- a/tests/causal_estimators/test_conditional_effects.py
+++ b/tests/causal_estimators/test_conditional_effects.py
@@ -77,4 +77,5 @@ def test_conditional_effects_all_missing_multiple_effect_modifiers_returns_empty
 
     assert conditional_estimates.empty
     assert isinstance(conditional_estimates.index, pd.MultiIndex)
-    assert conditional_estimates.index.names == ["__categorical__modifier_a", "__categorical__modifier_b"]
+    prefix = CausalEstimator.TEMP_CAT_COLUMN_PREFIX
+    assert conditional_estimates.index.names == [f"{prefix}modifier_a", f"{prefix}modifier_b"]

--- a/tests/causal_estimators/test_conditional_effects.py
+++ b/tests/causal_estimators/test_conditional_effects.py
@@ -7,6 +7,11 @@ Regression test for conditional effect estimation across effect modifiers.
 These tests confirm conditional effects are computed for single and multiple
 effect modifiers, and that the estimators can still access the effect-modifier
 (grouping) columns during feature construction.
+
+Constant numeric effect modifiers are also covered. Quantile discretization
+cannot create bins for a constant column, but it should still produce the one
+observed conditional-effect group instead of crashing while constructing the
+result index.
 """
 
 import numpy as np
@@ -14,9 +19,11 @@ import pandas as pd
 
 import dowhy.datasets
 from dowhy import CausalModel
+from dowhy.causal_estimator import CausalEstimator
+from dowhy.causal_identifier.identified_estimand import IdentifiedEstimand
 
 
-def _conditional_estimates(num_effect_modifiers):
+def _conditional_estimates(num_effect_modifiers, constant_effect_modifiers=False):
     data = dowhy.datasets.linear_dataset(
         beta=10,
         num_common_causes=3,
@@ -24,6 +31,8 @@ def _conditional_estimates(num_effect_modifiers):
         num_samples=2000,
         treatment_is_binary=True,
     )
+    if constant_effect_modifiers:
+        data["df"].loc[:, data["effect_modifier_names"]] = 0.0
     model = CausalModel(
         data=data["df"],
         treatment=data["treatment_name"],
@@ -48,3 +57,24 @@ def test_conditional_effects_multiple_effect_modifiers():
     assert isinstance(conditional_estimates.index, pd.MultiIndex)
     assert len(conditional_estimates) > 0
     assert np.all(np.isfinite(conditional_estimates.values))
+
+
+def test_conditional_effects_constant_multiple_effect_modifiers():
+    conditional_estimates = _conditional_estimates(num_effect_modifiers=2, constant_effect_modifiers=True)
+    assert isinstance(conditional_estimates, pd.Series)
+    assert isinstance(conditional_estimates.index, pd.MultiIndex)
+    assert conditional_estimates.index.nlevels == 2
+    assert len(conditional_estimates) == 1
+    assert np.all(np.isfinite(conditional_estimates.values))
+
+
+def test_conditional_effects_all_missing_multiple_effect_modifiers_returns_empty_multiindex():
+    estimator = CausalEstimator(IdentifiedEstimand(None, "treatment", "outcome"))
+    estimator._effect_modifier_names = ["modifier_a", "modifier_b"]
+    data = pd.DataFrame({"modifier_a": [np.nan], "modifier_b": [np.nan]})
+
+    conditional_estimates = estimator._estimate_conditional_effects(data, lambda _: 0.0)
+
+    assert conditional_estimates.empty
+    assert isinstance(conditional_estimates.index, pd.MultiIndex)
+    assert conditional_estimates.index.names == ["__categorical__modifier_a", "__categorical__modifier_b"]


### PR DESCRIPTION
## Summary

Fix conditional-effect estimation when numeric effect modifiers are constant or contain no observed groups.

`pd.qcut(..., duplicates="drop")` returns an all-NA categorical for a constant column. When all effect modifiers have that shape, the observed groupby is empty and the resulting one-level empty `Series` cannot be assigned multiple index names. This is the failure currently surfaced by the ranking notebook in Advanced Tests.

This change:

- preserves a constant non-null numeric modifier as its single observed category;
- constructs the conditional-effect index explicitly, so multiple modifiers always produce a `MultiIndex`, including when no groups are observed;
- keeps the grouping columns available to estimator feature construction as required by the pandas 3 compatibility path.

## Tests

- Added an integration regression test with two constant numeric effect modifiers.
- Added coverage for two all-missing modifiers returning an empty, correctly named `MultiIndex`.
- Ran the conditional-effects tests and the adjacent `CausalModel` CATE/public API tests on Python 3.13, pandas 3.0.5, and scikit-learn 1.9.0: 7 passed.
- Black, isort, flake8 hard-error checks, and the function-complexity check pass.

Closes #1769
