### PR TITLE
Fix CausalModel.learn_graph() always raising TypeError from init_graph()

### DIFF
--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -227,7 +227,7 @@ class CausalModel:
         graph = model.learn_graph()
 
         # Initialize causal graph object
-        self.init_graph(graph=graph)
+        self.init_graph(graph=graph, identify_vars=False)
 
         return self._graph
 

--- a/tests/test_causal_model.py
+++ b/tests/test_causal_model.py
@@ -658,6 +658,36 @@ class TestCausalModel(object):
                 graph=nx.Graph([("X", "Y"), ("Y", "Z")]),
             )
 
+    def test_learn_graph_initializes_the_graph(self):
+        """CausalModel.learn_graph() must pass identify_vars on to init_graph()."""
+        import sys
+        import types
+
+        from dowhy.graph_learner import GraphLearner
+
+        class STUB(GraphLearner):
+            def __init__(self, data, library_class=None, *args, **kwargs):
+                self._data = data
+
+            def learn_graph(self):
+                learned = nx.DiGraph([("W0", "v0"), ("W0", "y"), ("v0", "y")])
+                return nx.nx_pydot.to_pydot(learned).to_string()
+
+        module = types.ModuleType("dowhy.graph_learners.stub")
+        module.STUB = STUB
+        sys.modules["dowhy.graph_learners.stub"] = module
+        try:
+            data = pd.DataFrame({"W0": [0.0, 1.0, 2.0], "v0": [0, 1, 0], "y": [1.0, 3.0, 2.0]})
+            model = CausalModel(data=data, treatment="v0", outcome="y", common_causes=["W0"])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                graph = model.learn_graph("stub")
+        finally:
+            del sys.modules["dowhy.graph_learners.stub"]
+
+        assert graph is model._graph
+        assert set(graph.get_all_nodes(include_unobserved=True)) == {"W0", "v0", "y"}
+
     def test_warn_when_treatment_not_in_data(self):
         """CausalModel should emit a UserWarning when treatment variable is missing from the DataFrame."""
         data = pd.DataFrame({"X": [0, 1], "Y": [1, 2]})


### PR DESCRIPTION
## The bug

`CausalModel.learn_graph()` raises `TypeError` on every call:

```python
# dowhy/causal_model.py:158
def init_graph(self, graph, identify_vars):
    ...

# dowhy/causal_model.py:230, inside learn_graph()
self.init_graph(graph=graph)          # identify_vars is not passed
```

`__init__` calls it correctly (`self.init_graph(graph=graph, identify_vars=identify_vars)` at line 119); `learn_graph()` is the only other call site and it is the one that is wrong. Discovery runs to completion, then the result is thrown away by the crash:

```
TypeError: CausalModel.init_graph() missing 1 required positional argument: 'identify_vars'
```

This is long-standing — the same mismatch is present in v0.8, v0.10 and v0.11.1 — which suggests nothing exercises this path today. `learn_graph()` is deprecated, but it is still shipped, still documented, and currently cannot be called at all; a one-line fix seemed better than leaving a public method that always throws until the removal lands. Happy to close this if you would rather just delete the method.

## The fix

Pass `identify_vars=False`, which is `__init__`'s own default and the behaviour `learn_graph()` implicitly assumed (`identify_vars` is not stored on the model, so there is nothing else to forward).

## Test

`test_learn_graph_initializes_the_graph` drives the real `learn_graph()` path end to end. It registers a tiny stub `GraphLearner` into `sys.modules` (and removes it again in `finally`) so the test does not need `cdt`, `ges` or `lingam` installed, and asserts the graph actually lands on `model._graph`.

Run against `tests/test_causal_model.py` on this machine (Python 3.12):

```
# before the fix
FAILED tests/test_causal_model.py::TestCausalModel::test_graph_input_nx[10-1-100-1]
FAILED tests/test_causal_model.py::TestCausalModel::test_learn_graph_initializes_the_graph
2 failed, 23 passed

# after the fix
FAILED tests/test_causal_model.py::TestCausalModel::test_graph_input_nx[10-1-100-1]
1 failed, 24 passed
```

`test_graph_input_nx` fails identically with and without this change — it is pre-existing on `main` here and unrelated to `learn_graph`.

`black` and `isort` (repo `pyproject.toml` settings, line length 120) report no changes for either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
