### PR TITLE
fix(errors): stop silently dropping .format() arguments in two error messages

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -399,7 +399,7 @@ class CausalEstimator:
         return est
 
     def construct_symbolic_estimator(self, estimand):
-        raise NotImplementedError(("Symbolic estimator string is ").format(self.__class__))
+        raise NotImplementedError("Symbolic estimator string is not implemented for {0}.".format(self.__class__))
 
     def _generate_bootstrap_estimates(self, data: pd.DataFrame, num_bootstrap_simulations, sample_size_fraction):
         """Helper function to generate causal estimates over bootstrapped samples.

--- a/dowhy/causal_identifier/auto_identifier.py
+++ b/dowhy/causal_identifier/auto_identifier.py
@@ -220,7 +220,7 @@ def identify_effect_auto(
         )
     else:
         raise ValueError(
-            "Estimand type is not supported. Use either {0}, {1}, or {2}.".format(
+            "Estimand type is not supported. Use either {0}, {1}, {2}, or {3}.".format(
                 EstimandType.NONPARAMETRIC_ATE,
                 EstimandType.NONPARAMETRIC_CDE,
                 EstimandType.NONPARAMETRIC_NDE,


### PR DESCRIPTION
Two error messages call `str.format()` with more arguments than the format string has placeholders. `str.format` ignores the surplus silently, so in both cases the value the author meant to show is discarded.

Found with `pyflakes` (`'...'.format(...) has unused arguments at position(s): N`). These are the only two occurrences in `dowhy/`.

---

### 1. `dowhy/causal_estimator.py:402` — the class name never reaches the message

```python
def construct_symbolic_estimator(self, estimand):
    raise NotImplementedError(("Symbolic estimator string is ").format(self.__class__))
```

The literal has no placeholder, so `self.__class__` is dropped and the exception message is the dangling fragment `"Symbolic estimator string is "` — it names neither the class nor what went wrong.

This is reachable, not just an abstract stub. `RegressionEstimator` (docstring: *"Base class for all regression models, inherited by ..."*) does **not** define `construct_symbolic_estimator`, and calls it from `fit()`:

```
dowhy/causal_estimators/regression_estimator.py:113:
    self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
```

So `RegressionEstimator` itself, and any third-party subclass of it that follows the documented pattern without overriding the method, raises this message.

### 2. `dowhy/causal_identifier/auto_identifier.py:223` — `NONPARAMETRIC_NIE` dropped from the list of supported types

```python
raise ValueError(
    "Estimand type is not supported. Use either {0}, {1}, or {2}.".format(
        EstimandType.NONPARAMETRIC_ATE,
        EstimandType.NONPARAMETRIC_CDE,
        EstimandType.NONPARAMETRIC_NDE,
        EstimandType.NONPARAMETRIC_NIE,   # <- 4th argument, only 3 placeholders
    )
)
```

Four values, three placeholders. The message therefore advertises ATE, CDE and NDE and omits NIE — even though `identify_effect_auto` handles `NONPARAMETRIC_NIE` twelve lines above:

```
dowhy/causal_identifier/auto_identifier.py:213:
    elif estimand_type == EstimandType.NONPARAMETRIC_NIE:
        return identify_nie_effect(...)
```

A user who mistypes an estimand type is told that a supported option is not supported.

The sibling fallback in the same file gets the arity right, and is the spec followed here:

```
dowhy/causal_identifier/auto_identifier.py:1156:
    "Estimand type not supported. Supported estimand types are {0} or {1}'.".format(
        EstimandType.NONPARAMETRIC_NDE,
        EstimandType.NONPARAMETRIC_NIE,
    )
```

---

### Before / after

Rendered by evaluating the real expressions extracted from the source with `ast` (no hand-transcription), using the real `EstimandType` members:

**`causal_estimator.py`**

| | message |
|---|---|
| before | `NotImplementedError('Symbolic estimator string is ')` |
| after | `NotImplementedError("Symbolic estimator string is not implemented for <class '...RegressionEstimator'>.")` |

**`auto_identifier.py`**

| | message |
|---|---|
| before | `Estimand type is not supported. Use either EstimandType.NONPARAMETRIC_ATE, EstimandType.NONPARAMETRIC_CDE, or EstimandType.NONPARAMETRIC_NDE.` |
| after | `Estimand type is not supported. Use either EstimandType.NONPARAMETRIC_ATE, EstimandType.NONPARAMETRIC_CDE, EstimandType.NONPARAMETRIC_NDE, or EstimandType.NONPARAMETRIC_NIE.` |

### Scope

Diagnostics only — no behavioural change to any estimation or identification path. `+2 / -2`, `black --check` and `isort --check` clean at the repo's configured `line-length = 120`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
